### PR TITLE
Feature/json view improvements and mcp validation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,6 @@
+{
+  "presets": [
+    "@babel/preset-env",
+    ["@babel/preset-react", {"runtime": "automatic"}]
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ npm run electron:build
 
 ## 🧪 Testing
 
-MCP Palette includes comprehensive testing capabilities:
+MCP Palette includes comprehensive testing capabilities, powered by [Jest](https://jestjs.io/) and [React Testing Library](https://testing-library.com/):
 
 ```bash
 # Run all tests
@@ -86,6 +86,22 @@ npm test:validator  # MCP validation tests
 npm test:components # Component tests
 npm test:validation # Validation tests
 ```
+
+**Testing Notes:**
+- All necessary dev dependencies (`jest`, `@testing-library/react`, `babel-jest`, etc.) are included in `package.json`.
+- File and style mocks are provided in `__mocks__/` for robust component testing.
+- Babel is used for modern JS/React syntax support (see `.babelrc`).
+
+## 🛠️ Babel
+
+MCP Palette uses [Babel](https://babeljs.io/) (see `.babelrc`) to enable modern JavaScript and React features, and to support Jest-based testing.
+
+## ⚡️ What’s New in 1.2.0
+
+- Full Jest + React Testing Library support
+- Babel configuration for modern JS/React and tests
+- File/style mocks for testing
+- Updated documentation
 
 ## 🧰 Architecture
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,26 @@ Build the application for your current platform:
 npm run electron:build
 ```
 
+## 🧪 Testing
+
+MCP Palette includes comprehensive testing capabilities:
+
+```bash
+# Run all tests
+npm test
+
+# Watch mode
+npm test:watch
+
+# Test coverage
+npm test:coverage
+
+# Run specific test suites
+npm test:validator  # MCP validation tests
+npm test:components # Component tests
+npm test:validation # Validation tests
+```
+
 ## 🧰 Architecture
 
 MCP Palette uses a "Server Master List + Profile Overrides" architecture:

--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,2 @@
+// File mock for images, videos, etc.
+module.exports = "test-file-stub";

--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,2 @@
+// Style mock file
+module.exports = {};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,34 @@
+module.exports = {
+  // The root directory that Jest should scan for tests and modules
+  rootDir: ".",
+
+  // The test environment that will be used for testing
+  testEnvironment: "jsdom",
+
+  // The glob patterns Jest uses to detect test files
+  testMatch: ["**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)"],
+
+  // An array of regexp pattern strings that are matched against all test paths
+  testPathIgnorePatterns: ["/node_modules/", "/dist/", "/build/"],
+
+  // Transform files with babel-jest or other transformers
+  transform: {
+    "^.+\\.(js|jsx|ts|tsx)$": "babel-jest",
+  },
+
+  // Set up Jest to use testing-library
+  setupFilesAfterEnv: ["<rootDir>/src/setupTests.js"],
+
+  // Mock files like CSS, images, etc.
+  moduleNameMapper: {
+    "\\.(css|less|scss|sass)$": "<rootDir>/__mocks__/styleMock.js",
+    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
+      "<rootDir>/__mocks__/fileMock.js",
+  },
+
+  // Coverage configuration
+  collectCoverageFrom: ["src/**/*.{js,jsx,ts,tsx}", "!src/**/*.d.ts"],
+
+  // Verbose output
+  verbose: true,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,16 +17,21 @@
         "react-monaco-editor": "^0.55.0"
       },
       "devDependencies": {
+        "@babel/core": "^7.24.5",
+        "@babel/preset-env": "^7.26.9",
+        "@babel/preset-react": "^7.26.3",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
         "@vitejs/plugin-react": "^4.0.3",
+        "babel-jest": "^29.7.0",
         "concurrently": "^8.2.1",
         "cross-env": "^7.0.3",
         "electron": "^29.0.0",
         "electron-builder": "^24.6.4",
         "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0",
         "vite": "^4.4.5",
         "wait-on": "^7.0.1"
       }
@@ -125,6 +130,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
+      "integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.0.tgz",
@@ -137,6 +155,77 @@
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.0.tgz",
+      "integrity": "sha512-vSGCvMecvFCd/BdpGlhpXYNhhC4ccxyvQWpbGL4CWbvfEoLFWUZuSuf7s9Aw70flgQF+6vptvgK2IfOnKlRmBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-member-expression-to-functions": "^7.25.9",
+        "@babel/helper-optimise-call-expression": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.26.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+        "@babel/traverse": "^7.27.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-regexp-features-plugin": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.0.tgz",
+      "integrity": "sha512-fO8l08T76v48BhpNRW/nQ0MxfnSdoSKUJBMjubOAYffsVuGG5qOfMq7N6Es7UJvi7Y8goXXo07EfcHZXDPuELQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "regexpu-core": "^6.2.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-define-polyfill-provider": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.4.tgz",
+      "integrity": "sha512-jljfR1rGnXXNWnmQg2K3+bvhkxB51Rl32QRaOTuwwjviGrHzIbSc8+x9CpraDtbT7mfyjXObULP4w/adunNwAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.22.6",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "debug": "^4.1.1",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.14.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
+      "integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -174,12 +263,75 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
+      "integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.26.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
       "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-remap-async-to-generator": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.9.tgz",
+      "integrity": "sha512-IZtukuUeBbhgOcaW2s06OXTzVNJR0ybm4W5xC1opWFFJMZbwRj5LCk+ByYH7WdZPZTt8KnFwA8pvjN2yqcPlgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-wrap-function": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.26.5.tgz",
+      "integrity": "sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.25.9",
+        "@babel/helper-optimise-call-expression": "^7.25.9",
+        "@babel/traverse": "^7.26.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
+      "integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -214,6 +366,21 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-wrap-function": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.9.tgz",
+      "integrity": "sha512-ETzz9UTjQSTmw39GboatdymDq4XIQbR8ySgVrylRhPOFpsd+JrKHIuF0de7GCWmem+T4uC5z7EZguod7Wj4A4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helpers": {
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
@@ -242,6 +409,103 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.9.tgz",
+      "integrity": "sha512-ZkRyVkThtxQ/J6nv3JFYv1RYY+JT5BvU0y3k5bWrmuG4woXypRa4PXmm9RhOwodRkYFWqC0C0cqcJ4OqR7kW+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.9.tgz",
+      "integrity": "sha512-MrGRLZxLD/Zjj0gdU15dfs+HH/OXvnw/U4jJD8vpcP2CJQapPEv1IWwjc/qMg7ItBlPwSv1hRBbb7LeuANdcnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.9.tgz",
+      "integrity": "sha512-2qUwwfAFpJLZqxd02YW9btUCZHl+RFvdDkNfZwaIJrvB8Tesjsk8pEQkTvGwZXLqXUx/2oyY3ySRhm6HOXuCug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.25.9.tgz",
+      "integrity": "sha512-6xWgLZTJXwilVjlnV7ospI3xi+sl8lN8rXXbBD6vYn3UYDlGsag8wrZkKcSI8G6KgqKP7vNFaDgeDnfAABq61g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+        "@babel/plugin-transform-optional-chaining": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.13.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.9.tgz",
+      "integrity": "sha512-aLnMXYPnzwwqhYSCyXfKkIkYgJ8zv9RK+roo9DkTXz38ynIhd9XCbN08s3MGvqL2MYGVUGdRQLL/JqBIeJhJBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
@@ -291,6 +555,22 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-assertions": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.26.0.tgz",
+      "integrity": "sha512-QCWT5Hh830hK5EQa7XzuqIkQU9tT/whqbDz7kuaZMHFl1inRRg7JnuAEOQ0Ur0QUl0NufCk1msK2BeY79Aj/eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -483,6 +763,714 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
+      "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-arrow-functions": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.25.9.tgz",
+      "integrity": "sha512-6jmooXYIwn9ca5/RylZADJ+EnSxVUS5sjeJ9UPk6RWRzXCmOJCy6dqItPJFpw2cuCangPK4OYr5uhGKcmrm5Qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-generator-functions": {
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.26.8.tgz",
+      "integrity": "sha512-He9Ej2X7tNf2zdKMAGOsmg2MrFc+hfoAhd3po4cWfo/NWjzEAKa0oQruj1ROVUdl0e6fb6/kE/G3SSxE0lRJOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.26.5",
+        "@babel/helper-remap-async-to-generator": "^7.25.9",
+        "@babel/traverse": "^7.26.8"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-to-generator": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.25.9.tgz",
+      "integrity": "sha512-NT7Ejn7Z/LjUH0Gv5KsBCxh7BH3fbLTV0ptHvpeMvrt3cPThHfJfst9Wrb7S8EvJ7vRTFI7z+VAvFVEQn/m5zQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-remap-async-to-generator": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.26.5.tgz",
+      "integrity": "sha512-chuTSY+hq09+/f5lMj8ZSYgCFpppV2CbYrhNFJ1BFoXpiWPnnAb7R0MqrafCpN8E1+YRrtM1MXZHJdIx8B6rMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.26.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoping": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.0.tgz",
+      "integrity": "sha512-u1jGphZ8uDI2Pj/HJj6YQ6XQLZCNjOlprjxB5SVz6rq2T6SwAR+CdrWK0CP7F+9rDVMXdB0+r6Am5G5aobOjAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.26.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-properties": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.9.tgz",
+      "integrity": "sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-static-block": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.26.0.tgz",
+      "integrity": "sha512-6J2APTs7BDDm+UMqP1useWqhcRAXo0WIoVj26N7kPFB6S73Lgvyka4KTZYIxtgYXiN5HTyRObA72N2iu628iTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-classes": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.9.tgz",
+      "integrity": "sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-computed-properties": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.25.9.tgz",
+      "integrity": "sha512-HnBegGqXZR12xbcTHlJ9HGxw1OniltT26J5YpfruGqtUHlz/xKf/G2ak9e+t0rVqrjXa9WOhvYPz1ERfMj23AA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/template": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-destructuring": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.25.9.tgz",
+      "integrity": "sha512-WkCGb/3ZxXepmMiX101nnGiU+1CAdut8oHyEOHxkKuS1qKpU2SMXE2uSvfz8PBuLd49V6LEsbtyPhWC7fnkgvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dotall-regex": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.25.9.tgz",
+      "integrity": "sha512-t7ZQ7g5trIgSRYhI9pIJtRl64KHotutUJsh4Eze5l7olJv+mRSg4/MmbZ0tv1eeqRbdvo/+trvJD/Oc5DmW2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-keys": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.25.9.tgz",
+      "integrity": "sha512-LZxhJ6dvBb/f3x8xwWIuyiAHy56nrRG3PeYTpBkkzkYRRQ6tJLu68lEF5VIqMUZiAV7a8+Tb78nEoMCMcqjXBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.9.tgz",
+      "integrity": "sha512-0UfuJS0EsXbRvKnwcLjFtJy/Sxc5J5jhLHnFhy7u4zih97Hz6tJkLU+O+FMMrNZrosUPxDi6sYxJ/EA8jDiAog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dynamic-import": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.25.9.tgz",
+      "integrity": "sha512-GCggjexbmSLaFhqsojeugBpeaRIgWNTcgKVq/0qIteFEqY2A+b9QidYadrWlnbWQUrW5fn+mCvf3tr7OeBFTyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.26.3.tgz",
+      "integrity": "sha512-7CAHcQ58z2chuXPWblnn1K6rLDnDWieghSOEmqQsrBenH0P9InCUtOJYD89pvngljmZlJcz3fcmgYsXFNGa1ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-export-namespace-from": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.25.9.tgz",
+      "integrity": "sha512-2NsEz+CxzJIVOPx2o9UsW1rXLqtChtLoVnwYHHiB04wS5sgn7mrV45fWMBX0Kk+ub9uXytVYfNP2HjbVbCB3Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-for-of": {
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.26.9.tgz",
+      "integrity": "sha512-Hry8AusVm8LW5BVFgiyUReuoGzPUpdHQQqJY5bZnbbf+ngOHWuCuYFKw/BqaaWlvEUrF91HMhDtEaI1hZzNbLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.26.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-function-name": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.9.tgz",
+      "integrity": "sha512-8lP+Yxjv14Vc5MuWBpJsoUCd3hD6V9DgBon2FVYL4jJgbnVQ9fTgYmonchzZJOVNgzEgbxp4OwAf6xz6M/14XA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-json-strings": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.25.9.tgz",
+      "integrity": "sha512-xoTMk0WXceiiIvsaquQQUaLLXSW1KJ159KP87VilruQm0LNNGxWzahxSS6T6i4Zg3ezp4vA4zuwiNUR53qmQAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-literals": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.9.tgz",
+      "integrity": "sha512-9N7+2lFziW8W9pBl2TzaNht3+pgMIRP74zizeCSrtnSKVdUl8mAjjOP2OOVQAfZ881P2cNjDj1uAMEdeD50nuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-logical-assignment-operators": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.25.9.tgz",
+      "integrity": "sha512-wI4wRAzGko551Y8eVf6iOY9EouIDTtPb0ByZx+ktDGHwv6bHFimrgJM/2T021txPZ2s4c7bqvHbd+vXG6K948Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-member-expression-literals": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.25.9.tgz",
+      "integrity": "sha512-PYazBVfofCQkkMzh2P6IdIUaCEWni3iYEerAsRWuVd8+jlM1S9S9cz1dF9hIzyoZ8IA3+OwVYIp9v9e+GbgZhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-amd": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.25.9.tgz",
+      "integrity": "sha512-g5T11tnI36jVClQlMlt4qKDLlWnG5pP9CSM4GhdRciTNMRgkfpo5cR6b4rGIOYPgRRuFAvwjPQ/Yk+ql4dyhbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.26.3.tgz",
+      "integrity": "sha512-MgR55l4q9KddUDITEzEFYn5ZsGDXMSsU9E+kh7fjRXTIC3RHqfCo8RPRbyReYJh44HQ/yomFkqbOFohXvDCiIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-systemjs": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.9.tgz",
+      "integrity": "sha512-hyss7iIlH/zLHaehT+xwiymtPOpsiwIIRlCAOwBB04ta5Tt+lNItADdlXw3jAWZ96VJ2jlhl/c+PNIQPKNfvcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-umd": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.25.9.tgz",
+      "integrity": "sha512-bS9MVObUgE7ww36HEfwe6g9WakQ0KF07mQF74uuXdkoziUPfKyu/nIm663kz//e5O1nPInPFx36z7WJmJ4yNEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.25.9.tgz",
+      "integrity": "sha512-oqB6WHdKTGl3q/ItQhpLSnWWOpjUJLsOCLVyeFgeTktkBSCiurvPOsyt93gibI9CmuKvTUEtWmG5VhZD+5T/KA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-new-target": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.25.9.tgz",
+      "integrity": "sha512-U/3p8X1yCSoKyUj2eOBIx3FOn6pElFOKvAAGf8HTtItuPyB+ZeOqfn+mvTtg9ZlOAjsPdK3ayQEjqHjU/yLeVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+      "version": "7.26.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.6.tgz",
+      "integrity": "sha512-CKW8Vu+uUZneQCPtXmSBUC6NCAUdya26hWCElAWh5mVSlSRsmiCPUUDKb3Z0szng1hiAJa098Hkhg9o4SE35Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.26.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-numeric-separator": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.25.9.tgz",
+      "integrity": "sha512-TlprrJ1GBZ3r6s96Yq8gEQv82s8/5HnCVHtEJScUj90thHQbwe+E5MLhi2bbNHBEJuzrvltXSru+BUxHDoog7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-rest-spread": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.25.9.tgz",
+      "integrity": "sha512-fSaXafEE9CVHPweLYw4J0emp1t8zYTXyzN3UuG+lylqkvYd7RMrsOQ8TYx5RF231be0vqtFC6jnx3UmpJmKBYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/plugin-transform-parameters": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-super": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.25.9.tgz",
+      "integrity": "sha512-Kj/Gh+Rw2RNLbCK1VAWj2U48yxxqL2x0k10nPtSdRa0O2xnHXalD0s+o1A6a0W43gJ00ANo38jxkQreckOzv5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-catch-binding": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.25.9.tgz",
+      "integrity": "sha512-qM/6m6hQZzDcZF3onzIhZeDHDO43bkNNlOX0i8n3lR6zLbu0GN2d8qfM/IERJZYauhAHSLHy39NF0Ctdvcid7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-chaining": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.25.9.tgz",
+      "integrity": "sha512-6AvV0FsLULbpnXeBjrY4dmWF8F7gf8QnvTEoO/wX/5xm/xE1Xo8oPuD3MPS+KS9f9XBEAWN7X1aWr4z9HdOr7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-parameters": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.25.9.tgz",
+      "integrity": "sha512-wzz6MKwpnshBAiRmn4jR8LYz/g8Ksg0o80XmwZDlordjwEk9SxBzTWC7F5ef1jhbrbOW2DJ5J6ayRukrJmnr0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-methods": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.9.tgz",
+      "integrity": "sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-property-in-object": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.9.tgz",
+      "integrity": "sha512-Evf3kcMqzXA3xfYJmZ9Pg1OvKdtqsDMSWBDzZOPLvHiTt36E75jLDQo5w1gtRU95Q4E5PDttrTf25Fw8d/uWLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-property-literals": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.25.9.tgz",
+      "integrity": "sha512-IvIUeV5KrS/VPavfSM/Iu+RE6llrHrYIKY1yfCzyO/lMXHQ+p7uGhonmGVisv6tSBSVgWzMBohTcvkC9vQcQFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-display-name": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.25.9.tgz",
+      "integrity": "sha512-KJfMlYIUxQB1CJfO3e0+h0ZHWOTLCPP115Awhaz8U0Zpq36Gl/cXlpoyMRnUWlhNUBAzldnCiAZNvCDj7CrKxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.9.tgz",
+      "integrity": "sha512-s5XwpQYCqGerXl+Pu6VDL3x0j2d82eiV77UJ8a2mDHAW7j9SWRqQ2y1fNo1Z74CdcYipl5Z41zvjj4Nfzq36rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/plugin-syntax-jsx": "^7.25.9",
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-development": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.25.9.tgz",
+      "integrity": "sha512-9mj6rm7XVYs4mdLIpbZnHOYdpW42uoiBCTVowg7sP1thUOiANgMb4UtpRivR0pp5iL+ocvUv7X4mZgFRpJEzGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.25.9.tgz",
@@ -507,6 +1495,341 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-pure-annotations": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.25.9.tgz",
+      "integrity": "sha512-KQ/Takk3T8Qzj5TppkS1be588lkbTp5uj7w6a0LeQaTMSckU/wK0oJ/pih+T690tkgI5jfmg2TqDJvd41Sj1Cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-regenerator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.0.tgz",
+      "integrity": "sha512-LX/vCajUJQDqE7Aum/ELUMZAY19+cDpghxrnyt5I1tV6X5PyC86AOoWXWFYFeIvauyeSA6/ktn4tQVn/3ZifsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.26.5",
+        "regenerator-transform": "^0.15.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-regexp-modifiers": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.26.0.tgz",
+      "integrity": "sha512-vN6saax7lrA2yA/Pak3sCxuD6F5InBjn9IcrIKQPjpsLvuHYLVroTxjdlVRHjjBWxKOqIwpTXDkOssYT4BFdRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-reserved-words": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.25.9.tgz",
+      "integrity": "sha512-7DL7DKYjn5Su++4RXu8puKZm2XBPHyjWLUidaPEkCUBbE7IPcsrkRHggAOOKydH1dASWdcUBxrkOGNxUv5P3Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-shorthand-properties": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.9.tgz",
+      "integrity": "sha512-MUv6t0FhO5qHnS/W8XCbHmiRWOphNufpE1IVxhK5kuN3Td9FT1x4rx4K42s3RYdMXCXpfWkGSbCSd0Z64xA7Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-spread": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.25.9.tgz",
+      "integrity": "sha512-oNknIB0TbURU5pqJFVbOOFspVlrpVwo2H1+HUIsVDvp5VauGGDP1ZEvO8Nn5xyMEs3dakajOxlmkNW7kNgSm6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-sticky-regex": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.25.9.tgz",
+      "integrity": "sha512-WqBUSgeVwucYDP9U/xNRQam7xV8W5Zf+6Eo7T2SRVUFlhRiMNFdFz58u0KZmCVVqs2i7SHgpRnAhzRNmKfi2uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-template-literals": {
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.26.8.tgz",
+      "integrity": "sha512-OmGDL5/J0CJPJZTHZbi2XpO0tyT2Ia7fzpW5GURwdtp2X3fMmN8au/ej6peC/T33/+CRiIpA8Krse8hFGVmT5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.26.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typeof-symbol": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.0.tgz",
+      "integrity": "sha512-+LLkxA9rKJpNoGsbLnAgOCdESl73vwYn+V6b+5wHbrE7OGKVDPHIQvbFSzqE6rwqaCw2RE+zdJrlLkcf8YOA0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.26.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-escapes": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.25.9.tgz",
+      "integrity": "sha512-s5EDrE6bW97LtxOcGj1Khcx5AaXwiMmi4toFWRDP9/y0Woo6pXC+iyPu/KuhKtfSrNFd7jJB+/fkOtZy6aIC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-property-regex": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.25.9.tgz",
+      "integrity": "sha512-Jt2d8Ga+QwRluxRQ307Vlxa6dMrYEMZCgGxoPR8V52rxPyldHu3hdlHspxaqYmE7oID5+kB+UKUB/eWS+DkkWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-regex": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.25.9.tgz",
+      "integrity": "sha512-yoxstj7Rg9dlNn9UQxzk4fcNivwv4nUYz7fYXBaKxvw/lnmPuOm/ikoELygbYq68Bls3D/D+NBPHiLwZdZZ4HA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-sets-regex": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.9.tgz",
+      "integrity": "sha512-8BYqO3GeVNHtx69fdPshN3fnzUNLrWdHhk/icSwigksJGczKSizZ+Z6SBCxTs723Fr5VSNorTIK7a+R2tISvwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/preset-env": {
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.9.tgz",
+      "integrity": "sha512-vX3qPGE8sEKEAZCWk05k3cpTAE3/nOYca++JA+Rd0z2NCNzabmYvEiSShKzm10zdquOIAVXsy2Ei/DTW34KlKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.26.8",
+        "@babel/helper-compilation-targets": "^7.26.5",
+        "@babel/helper-plugin-utils": "^7.26.5",
+        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.9",
+        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.9",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.9",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.25.9",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.9",
+        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+        "@babel/plugin-syntax-import-assertions": "^7.26.0",
+        "@babel/plugin-syntax-import-attributes": "^7.26.0",
+        "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
+        "@babel/plugin-transform-arrow-functions": "^7.25.9",
+        "@babel/plugin-transform-async-generator-functions": "^7.26.8",
+        "@babel/plugin-transform-async-to-generator": "^7.25.9",
+        "@babel/plugin-transform-block-scoped-functions": "^7.26.5",
+        "@babel/plugin-transform-block-scoping": "^7.25.9",
+        "@babel/plugin-transform-class-properties": "^7.25.9",
+        "@babel/plugin-transform-class-static-block": "^7.26.0",
+        "@babel/plugin-transform-classes": "^7.25.9",
+        "@babel/plugin-transform-computed-properties": "^7.25.9",
+        "@babel/plugin-transform-destructuring": "^7.25.9",
+        "@babel/plugin-transform-dotall-regex": "^7.25.9",
+        "@babel/plugin-transform-duplicate-keys": "^7.25.9",
+        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.9",
+        "@babel/plugin-transform-dynamic-import": "^7.25.9",
+        "@babel/plugin-transform-exponentiation-operator": "^7.26.3",
+        "@babel/plugin-transform-export-namespace-from": "^7.25.9",
+        "@babel/plugin-transform-for-of": "^7.26.9",
+        "@babel/plugin-transform-function-name": "^7.25.9",
+        "@babel/plugin-transform-json-strings": "^7.25.9",
+        "@babel/plugin-transform-literals": "^7.25.9",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.25.9",
+        "@babel/plugin-transform-member-expression-literals": "^7.25.9",
+        "@babel/plugin-transform-modules-amd": "^7.25.9",
+        "@babel/plugin-transform-modules-commonjs": "^7.26.3",
+        "@babel/plugin-transform-modules-systemjs": "^7.25.9",
+        "@babel/plugin-transform-modules-umd": "^7.25.9",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.25.9",
+        "@babel/plugin-transform-new-target": "^7.25.9",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.26.6",
+        "@babel/plugin-transform-numeric-separator": "^7.25.9",
+        "@babel/plugin-transform-object-rest-spread": "^7.25.9",
+        "@babel/plugin-transform-object-super": "^7.25.9",
+        "@babel/plugin-transform-optional-catch-binding": "^7.25.9",
+        "@babel/plugin-transform-optional-chaining": "^7.25.9",
+        "@babel/plugin-transform-parameters": "^7.25.9",
+        "@babel/plugin-transform-private-methods": "^7.25.9",
+        "@babel/plugin-transform-private-property-in-object": "^7.25.9",
+        "@babel/plugin-transform-property-literals": "^7.25.9",
+        "@babel/plugin-transform-regenerator": "^7.25.9",
+        "@babel/plugin-transform-regexp-modifiers": "^7.26.0",
+        "@babel/plugin-transform-reserved-words": "^7.25.9",
+        "@babel/plugin-transform-shorthand-properties": "^7.25.9",
+        "@babel/plugin-transform-spread": "^7.25.9",
+        "@babel/plugin-transform-sticky-regex": "^7.25.9",
+        "@babel/plugin-transform-template-literals": "^7.26.8",
+        "@babel/plugin-transform-typeof-symbol": "^7.26.7",
+        "@babel/plugin-transform-unicode-escapes": "^7.25.9",
+        "@babel/plugin-transform-unicode-property-regex": "^7.25.9",
+        "@babel/plugin-transform-unicode-regex": "^7.25.9",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.25.9",
+        "@babel/preset-modules": "0.1.6-no-external-plugins",
+        "babel-plugin-polyfill-corejs2": "^0.4.10",
+        "babel-plugin-polyfill-corejs3": "^0.11.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.1",
+        "core-js-compat": "^3.40.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-modules": {
+      "version": "0.1.6-no-external-plugins",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+      "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/preset-react": {
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.26.3.tgz",
+      "integrity": "sha512-Nl03d6T9ky516DGK2YMxrTqvnpUW63TnJMOMonj+Zae0JiPC5BC9xPMSL6L8fiSpA5vP88qfygavVQvnLp+6Cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/plugin-transform-react-display-name": "^7.25.9",
+        "@babel/plugin-transform-react-jsx": "^7.25.9",
+        "@babel/plugin-transform-react-jsx-development": "^7.25.9",
+        "@babel/plugin-transform-react-pure-annotations": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2266,6 +3589,18 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
@@ -2348,6 +3683,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/verror": {
       "version": "1.10.11",
       "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
@@ -2420,6 +3762,51 @@
       "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/acorn": {
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -2913,6 +4300,48 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs2": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz",
+      "integrity": "sha512-3sX/eOms8kd3q2KZ6DAhKPc0dgm525Gqq5NtWKZ7QYYZEv57OQ54KtblzJzH1lQF/eQxO8KjWGIK9IPUJNus5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.22.6",
+        "@babel/helper-define-polyfill-provider": "^0.6.4",
+        "semver": "^6.3.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
+      "integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.3",
+        "core-js-compat": "^3.40.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-regenerator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.4.tgz",
+      "integrity": "sha512-7gD3pRadPrbjhjLyxebmx/WrFYcuSjZ0XbdUujQMZ/fcE9oeewk2U/7PCvez84UeuK3oSjmPZ0Ch0dlupQvGzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
@@ -3680,6 +5109,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js-compat": {
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.41.0.tgz",
+      "integrity": "sha512-RFsU9LySVue9RTwdDVX/T0e2Y6jRYWXERKElIjpuEOEnxaXffI0X7RUwVzfYLfzuLXSNJDYoRYUAmRUcyln20A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.24.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -3790,11 +5233,53 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/date-fns": {
       "version": "2.30.0",
@@ -3845,6 +5330,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -4121,6 +5613,20 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/dot-prop": {
       "version": "6.0.1",
@@ -4435,6 +5941,19 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -4580,6 +6099,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -4592,6 +6133,26 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/execa": {
@@ -5259,6 +6820,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -5511,6 +7085,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -6080,6 +7661,34 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+      "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/jsdom": "^20.0.0",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jsdom": "^20.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
@@ -6696,6 +8305,52 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -6878,6 +8533,13 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true,
       "license": "MIT"
     },
@@ -7290,6 +8952,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
+      "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7414,6 +9083,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^4.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -7734,6 +9416,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
@@ -7770,6 +9465,13 @@
           "url": "https://opencollective.com/fast-check"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/quick-lru": {
@@ -7899,12 +9601,93 @@
         "node": ">=8"
       }
     },
+    "node_modules/regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/regenerate-unicode-properties": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
+      "integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerate": "^1.4.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/regenerator-transform": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
+      "integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.4"
+      }
+    },
+    "node_modules/regexpu-core": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz",
+      "integrity": "sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^10.2.0",
+        "regjsgen": "^0.8.0",
+        "regjsparser": "^0.12.0",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/regjsparser": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.12.0.tgz",
+      "integrity": "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "jsesc": "~3.0.2"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/regjsparser/node_modules/jsesc": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -7924,6 +9707,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -8100,6 +9890,19 @@
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -8528,6 +10331,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -8699,6 +10509,45 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -8769,6 +10618,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+      "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-value-ecmascript": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
+      "integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-property-aliases-ecmascript": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -8818,6 +10711,17 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/utf8-byte-length": {
@@ -8922,6 +10826,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/wait-on": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
@@ -8950,6 +10867,53 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which": {
@@ -9033,6 +10997,38 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -9042,6 +11038,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "mcp-manager",
-  "version": "1.0.0",
+  "name": "mcp-palette",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mcp-manager",
-      "version": "1.0.0",
+      "name": "mcp-palette",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17,6 +17,8 @@
         "react-monaco-editor": "^0.55.0"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.3.0",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
         "@vitejs/plugin-react": "^4.0.3",
@@ -24,9 +26,17 @@
         "cross-env": "^7.0.3",
         "electron": "^29.0.0",
         "electron-builder": "^24.6.4",
+        "jest": "^29.7.0",
         "vite": "^4.4.5",
         "wait-on": "^7.0.1"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.2.tgz",
+      "integrity": "sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -234,6 +244,245 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
+      "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
+      "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
+      "integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.25.9.tgz",
@@ -326,6 +575,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@develar/schema-utils": {
       "version": "2.6.5",
@@ -1112,6 +1368,441 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/core/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/core/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
@@ -1278,6 +1969,13 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -1289,6 +1987,26 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -1304,6 +2022,110 @@
         "node": ">=10"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
+      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "lodash": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -1313,6 +2135,14 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1392,12 +2222,49 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
@@ -1474,6 +2341,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/verror": {
       "version": "1.10.11",
       "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
@@ -1481,6 +2355,23 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -1609,6 +2500,35 @@
         "ajv": "^6.9.1"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1633,6 +2553,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/app-builder-bin": {
@@ -1822,6 +2756,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -1897,6 +2841,122 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
+      "integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1976,6 +3036,19 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.24.4",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
@@ -2007,6 +3080,16 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
       }
     },
     "node_modules/buffer": {
@@ -2184,6 +3267,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001714",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001714.tgz",
@@ -2235,6 +3338,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/chownr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
@@ -2267,6 +3380,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cli-truncate": {
       "version": "2.1.0",
@@ -2313,6 +3433,24 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -2589,6 +3727,28 @@
         "node": ">= 10"
       }
     },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/cross-env": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -2622,6 +3782,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -2708,6 +3875,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/dedent": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
+      "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
@@ -2766,6 +3958,26 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
@@ -2773,6 +3985,16 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/dir-compare": {
       "version": "3.3.0",
@@ -2891,6 +4113,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dot-prop": {
       "version": "6.0.1",
@@ -3175,6 +4405,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -3207,6 +4450,16 @@
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -3327,6 +4580,90 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -3388,6 +4725,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -3406,6 +4753,19 @@
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/find-up": {
@@ -3605,6 +4965,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/get-proto": {
@@ -3889,6 +5259,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
@@ -3937,6 +5314,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
       }
     },
     "node_modules/iconv-corefoundation": {
@@ -3991,6 +5378,46 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4010,6 +5437,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-ci": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
@@ -4023,6 +5457,22 @@
         "is-ci": "bin.js"
       }
     },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4033,6 +5483,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-obj": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
@@ -4040,6 +5510,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -4069,6 +5552,103 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -4129,6 +5709,960 @@
         "node": "*"
       }
     },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-circus/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-config/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-each/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-validate/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/joi": {
       "version": "17.13.3",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
@@ -4179,6 +6713,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -4234,6 +6775,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/lazy-val": {
@@ -4292,6 +6843,23 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "3.0.0",
@@ -4385,6 +6953,56 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
     "node_modules/matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -4407,6 +7025,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/mime": {
@@ -4458,6 +7097,16 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4576,6 +7225,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-addon-api": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
@@ -4583,6 +7239,13 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.19",
@@ -4597,7 +7260,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4613,6 +7275,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/object-assign": {
@@ -4722,6 +7397,25 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -4750,6 +7444,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
@@ -4788,6 +7489,92 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pkg-up": {
       "version": "3.1.0",
@@ -4845,6 +7632,44 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -4875,6 +7700,20 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/prop-types": {
@@ -4915,6 +7754,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
@@ -5029,6 +7885,20 @@
         "minimatch": "^5.1.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
@@ -5055,12 +7925,66 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/responselike": {
       "version": "2.0.1",
@@ -5310,6 +8234,23 @@
         "node": ">=10"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
@@ -5383,6 +8324,29 @@
       "license": "BSD-3-Clause",
       "optional": true
     },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -5402,6 +8366,20 @@
       "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/string-width": {
@@ -5462,6 +8440,52 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/sumchecker": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
@@ -5489,6 +8513,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/tar": {
@@ -5583,6 +8620,45 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
@@ -5601,6 +8677,26 @@
       "license": "MIT",
       "dependencies": {
         "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/tree-kill": {
@@ -5629,6 +8725,16 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/type-fest": {
       "version": "2.19.0",
@@ -5729,6 +8835,21 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/verror": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
@@ -5821,6 +8942,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5878,6 +9009,27 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -5946,6 +9098,19 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zip-stream": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",
-    "@babel/preset-env": "^7.24.5",
-    "@babel/preset-react": "^7.24.5",
+    "@babel/preset-env": "^7.26.9",
+    "@babel/preset-react": "^7.26.3",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^18.2.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-palette",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A palette for Model Context Protocol servers",
   "author": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,13 @@
     "postinstall": "node chmod.js",
     "make-executable": "node chmod.js",
     "fix": "node chmod.js && ./fix-and-rebuild.sh",
-    "fix-enter": "node chmod.js && ./fix-enter-key.sh"
+    "fix-enter": "node chmod.js && ./fix-enter-key.sh",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "test:validator": "jest src/utils/validation/__tests__/mcpValidator.test.js",
+    "test:components": "jest src/components",
+    "test:validation": "jest src/components/validation"
   },
   "dependencies": {
     "electron-store": "^8.1.0",
@@ -25,13 +31,21 @@
     "react-monaco-editor": "^0.55.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.24.5",
+    "@babel/preset-env": "^7.24.5",
+    "@babel/preset-react": "^7.24.5",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.0.3",
+    "babel-jest": "^29.7.0",
     "concurrently": "^8.2.1",
     "cross-env": "^7.0.3",
     "electron": "^29.0.0",
     "electron-builder": "^24.6.4",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "vite": "^4.4.5",
     "wait-on": "^7.0.1"
   },

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,26 +2,18 @@
 
 # Make the script executable with: chmod +x run-tests.sh
 
-# Run tests for the MCP validation system
-echo "Running MCP Validator tests..."
-npx jest src/utils/validation/__tests__/mcpValidator.test.js
+# Run specific test categories
+echo "========== Running MCP Validator tests =========="
+npm run test:validator
 
-# Run tests for ValidationBadge component
-echo "Running ValidationBadge tests..."
-npx jest src/components/validation/__tests__/ValidationBadge.test.jsx
+echo ""
+echo "========== Running Validation Component tests =========="
+npm run test:validation
 
-# Run tests for ValidationDetails component
-echo "Running ValidationDetails tests..."
-npx jest src/components/validation/__tests__/ValidationDetails.test.jsx
+echo ""
+echo "========== Running Component Integration tests =========="
+npm run test:components
 
-# Run tests for ServerJsonViewer integration
-echo "Running ServerJsonViewer integration tests..."
-npx jest src/components/__tests__/ServerJsonViewer.test.jsx
-
-# Run tests for MasterServerForm integration
-echo "Running MasterServerForm integration tests..."
-npx jest src/components/__tests__/MasterServerForm.test.jsx
-
-# Run all tests
-echo "Running all tests..."
-npx jest
+echo ""
+echo "========== Running All Tests with Coverage =========="
+npm run test:coverage

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Make the script executable with: chmod +x run-tests.sh
+
+# Run tests for the MCP validation system
+echo "Running MCP Validator tests..."
+npx jest src/utils/validation/__tests__/mcpValidator.test.js
+
+# Run tests for ValidationBadge component
+echo "Running ValidationBadge tests..."
+npx jest src/components/validation/__tests__/ValidationBadge.test.jsx
+
+# Run tests for ValidationDetails component
+echo "Running ValidationDetails tests..."
+npx jest src/components/validation/__tests__/ValidationDetails.test.jsx
+
+# Run tests for ServerJsonViewer integration
+echo "Running ServerJsonViewer integration tests..."
+npx jest src/components/__tests__/ServerJsonViewer.test.jsx
+
+# Run tests for MasterServerForm integration
+echo "Running MasterServerForm integration tests..."
+npx jest src/components/__tests__/MasterServerForm.test.jsx
+
+# Run all tests
+echo "Running all tests..."
+npx jest

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -901,7 +901,7 @@ const App = () => {
                           : null
                       }
                       serverId={selectedServerMaster}
-                      onSave={handleSaveMasterServer}
+                      onSave={selectedServerMaster ? handleUpdateMasterServer : handleSaveMasterServer}
                       onCancel={() => {
                         setIsAddingServer(false);
                         setSelectedServerMaster(null);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import {
 } from "./utils/validation/mcpValidator";
 import { generateUUID, isValidUUID } from "./utils/helpers";
 import "./styles/index.css";
+import "./styles/validation.css";
 
 const App = () => {
   const [showConfirmRestoreModal, setShowConfirmRestoreModal] = useState(false);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,10 @@ import {
   findProfileByIdOrName,
   getServerDisplayName,
 } from "./utils/profileUtils";
+import {
+  formatSingleServerConfig,
+  formatServerListToMcpJson,
+} from "./utils/validation/mcpValidator";
 import { generateUUID, isValidUUID } from "./utils/helpers";
 import "./styles/index.css";
 
@@ -857,14 +861,10 @@ const App = () => {
                   {viewingServerJson && selectedServerMaster ? (
                     // View individual server JSON
                     <div className="server-json-viewer">
-                      <div className="server-json-header">
-                        <h2>
-                          MCP Configuration JSON - Server:{" "}
-                          {getServerDisplayName(
-                            serverMasterList[selectedServerMaster],
-                          )}
-                          <span className="readonly-badge">🔒 Read-Only</span>
-                        </h2>
+                      <div
+                        className="server-json-actions"
+                        style={{ textAlign: "right", marginBottom: "15px" }}
+                      >
                         <button
                           className="button button-secondary"
                           onClick={() => setViewingServerJson(false)}
@@ -876,14 +876,20 @@ const App = () => {
                       <JsonEditor
                         json={JSON.stringify(
                           {
-                            // Exclude the internal id field
-                            ...serverMasterList[selectedServerMaster],
+                            [getServerDisplayName(
+                              serverMasterList[selectedServerMaster],
+                            )]: formatSingleServerConfig(
+                              serverMasterList[selectedServerMaster],
+                            ),
                           },
                           null,
                           2,
                         )}
                         readOnly={true}
                         isProfileView={false}
+                        serverName={getServerDisplayName(
+                          serverMasterList[selectedServerMaster],
+                        )}
                       />
                     </div>
                   ) : isAddingServer || selectedServerMaster ? (
@@ -918,7 +924,11 @@ const App = () => {
                 </>
               ) : (
                 <JsonEditor
-                  json={JSON.stringify(serverMasterList, null, 2)}
+                  json={JSON.stringify(
+                    formatServerListToMcpJson(serverMasterList),
+                    null,
+                    2,
+                  )}
                   readOnly={true}
                   isProfileView={false}
                 />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -238,6 +238,7 @@ const App = () => {
   const handleAddMasterServer = () => {
     setSelectedServerMaster(null);
     setIsAddingServer(true);
+    setEditMode("form"); // Switch to form view when adding a server
   };
 
   // Handle saving a server to master list

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -268,9 +268,18 @@ const App = () => {
     try {
       const updatedMasterList = await window.api.updateMasterServer(
         serverId,
-        updatedServer,
+        updatedServer
       );
       setServerMasterList(updatedMasterList);
+      
+      // Reset state to return to the master list view
+      setSelectedServerMaster(null);
+      setIsAddingServer(false);
+      
+      // Show success message
+      await window.api.safeAlert(
+        `Server "${updatedServer.name}" updated successfully!`
+      );
     } catch (error) {
       console.error("Failed to update server:", error);
       await window.api.safeAlert("Failed to update server: " + error.message);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ import {
 import { generateUUID, isValidUUID } from "./utils/helpers";
 import "./styles/index.css";
 import "./styles/validation.css";
+import "./styles/overrides.css";
 
 const App = () => {
   const [showConfirmRestoreModal, setShowConfirmRestoreModal] = useState(false);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -908,7 +908,6 @@ const App = () => {
                         setIsAddingServer(false);
                         setSelectedServerMaster(null);
                       }}
-                      onViewJson={() => setViewingServerJson(true)}
                     />
                   ) : (
                     <ServerMasterList

--- a/src/components/JsonEditor.jsx
+++ b/src/components/JsonEditor.jsx
@@ -9,6 +9,7 @@ const JsonEditor = ({
   isProfileView = true,
   profileName = "",
   serverName = "",
+  hideTitle = false,
 }) => {
   const [editorContent, setEditorContent] = useState(json);
   const [error, setError] = useState(null);
@@ -183,13 +184,16 @@ const JsonEditor = ({
   return (
     <div className="json-editor">
       <div className="json-editor-header">
+        {!hideTitle && (
         <div className="json-editor-title">
           <h2>
             {isProfileView && profileName
               ? `MCP Configuration JSON - Profile: ${profileName}`
-              : serverName
-                ? `MCP Configuration JSON - Server: ${serverName}`
-                : "MCP Configuration JSON - All Servers"}{" "}
+              : serverName && profileName
+                ? `MCP Configuration JSON - Server: ${serverName} (Profile: ${profileName})`
+                : serverName
+                  ? `MCP Configuration JSON - Server: ${serverName}`
+                  : "MCP Configuration JSON - All Servers"}{" "}
             <span className="readonly-badge">🔒 Read-Only</span>
             {validationStatus.valid ? (
               <span className="validation-badge validation-success">
@@ -221,6 +225,7 @@ const JsonEditor = ({
             )}
           </p>
         </div>
+        )}
         <div className="json-editor-actions">
           <div className="json-editor-actions-container">
             <div

--- a/src/components/JsonEditor.jsx
+++ b/src/components/JsonEditor.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import MonacoEditor from "react-monaco-editor";
+import { validateMcpConfig } from "../utils/validation/mcpValidator";
 
 const JsonEditor = ({
   json,
@@ -7,15 +8,21 @@ const JsonEditor = ({
   onRestoreDefaults,
   isProfileView = true,
   profileName = "",
+  serverName = "",
 }) => {
   const [editorContent, setEditorContent] = useState(json);
   const [error, setError] = useState(null);
   const [copySuccess, setCopySuccess] = useState(false);
+  const [validationStatus, setValidationStatus] = useState({
+    valid: true,
+    errors: [],
+  });
   const editorRef = useRef(null);
 
   // Update content when json prop changes
   useEffect(() => {
     setEditorContent(json);
+    validateMcpFormat(json);
   }, [json]);
 
   // Clear copy success message after 2 seconds
@@ -25,6 +32,20 @@ const JsonEditor = ({
       return () => clearTimeout(timer);
     }
   }, [copySuccess]);
+
+  // Validate MCP format
+  const validateMcpFormat = (jsonContent) => {
+    try {
+      const parsed = JSON.parse(jsonContent);
+      const validationResult = validateMcpConfig(parsed);
+      setValidationStatus(validationResult);
+    } catch (err) {
+      setValidationStatus({
+        valid: false,
+        errors: ["Invalid JSON format: " + err.message],
+      });
+    }
+  };
 
   // Validate JSON content
   const validateJson = (content) => {
@@ -165,9 +186,20 @@ const JsonEditor = ({
         <div className="json-editor-title">
           <h2>
             {isProfileView && profileName
-              ? `MCP Configuration JSON - ${profileName}`
-              : "MCP Configuration JSON - Server Master List"}{" "}
+              ? `MCP Configuration JSON - Profile: ${profileName}`
+              : serverName
+                ? `MCP Configuration JSON - Server: ${serverName}`
+                : "MCP Configuration JSON - All Servers"}{" "}
             <span className="readonly-badge">🔒 Read-Only</span>
+            {validationStatus.valid ? (
+              <span className="validation-badge validation-success">
+                ✔ MCP Compliant
+              </span>
+            ) : (
+              <span className="validation-badge validation-error">
+                ✘ Not MCP Compliant
+              </span>
+            )}
           </h2>
           <p className="json-editor-subtitle">
             {isProfileView ? (
@@ -175,6 +207,11 @@ const JsonEditor = ({
                 This view displays the effective MCP-compliant configuration
                 with only enabled servers, showing values inherited from the
                 master list with profile-specific overrides applied.
+              </>
+            ) : serverName ? (
+              <>
+                This view displays the selected server configuration in
+                MCP-compliant format.
               </>
             ) : (
               <>
@@ -197,13 +234,15 @@ const JsonEditor = ({
               >
                 Copy to Clipboard
               </button>
-              <button
-                className="button button-secondary"
-                onClick={handleExportToJson}
-                title="Export JSON as file"
-              >
-                Export JSON
-              </button>
+              {!serverName && (
+                <button
+                  className="button button-secondary"
+                  onClick={handleExportToJson}
+                  title="Export JSON as file"
+                >
+                  Export JSON
+                </button>
+              )}
             </div>
 
             {copySuccess && (
@@ -218,6 +257,17 @@ const JsonEditor = ({
       {error && (
         <div className="json-editor-error">
           <p>Error: {error}</p>
+        </div>
+      )}
+
+      {!validationStatus.valid && validationStatus.errors.length > 0 && (
+        <div className="json-editor-validation-errors">
+          <h3>MCP Compliance Issues:</h3>
+          <ul>
+            {validationStatus.errors.map((err, index) => (
+              <li key={index}>{err}</li>
+            ))}
+          </ul>
         </div>
       )}
 

--- a/src/components/MasterServerForm.jsx
+++ b/src/components/MasterServerForm.jsx
@@ -2,9 +2,11 @@ import { useState, useEffect } from "react";
 import {
   validateMcpServerConfig,
   getValidationSummary,
+  formatSingleServerConfig,
 } from "../utils/validation/mcpValidator";
 import { ValidationBadge } from "./validation";
 import { validationPatterns } from "../utils/validation/mcpSchema";
+import ServerJsonViewer from "./ServerJsonViewer";
 
 const MasterServerForm = ({
   server,
@@ -24,6 +26,7 @@ const MasterServerForm = ({
   const [newEnvKey, setNewEnvKey] = useState("");
   const [newEnvValue, setNewEnvValue] = useState("");
   const [originalId, setOriginalId] = useState("");
+  const [showJsonPreview, setShowJsonPreview] = useState(false);
 
   // Add state for validation
   const [validationResult, setValidationResult] = useState(null);
@@ -133,6 +136,40 @@ const MasterServerForm = ({
     });
   };
 
+  // Generate preview JSON based on current form state
+  const generatePreviewJson = () => {
+    // Create a clean server object for JSON preview
+    const serverData = { ...formData };
+
+    // Add originalId if needed
+    if (originalId) {
+      serverData.originalId = originalId;
+    } else if (formData.name) {
+      // For new servers, set original ID to the name for preview
+      serverData.originalId = formData.name;
+    }
+
+    // Remove empty properties
+    if (formData.args && formData.args.length === 0) {
+      delete serverData.args;
+    }
+
+    if (formData.env && Object.keys(formData.env).length === 0) {
+      delete serverData.env;
+    }
+
+    return serverData;
+  };
+
+  // Handle JSON preview
+  const handleViewJson = () => {
+    setShowJsonPreview(true);
+  };
+
+  const handleBackFromJson = () => {
+    setShowJsonPreview(false);
+  };
+
   // Handle form submission
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -161,6 +198,17 @@ const MasterServerForm = ({
   const isValidEnvName = (name) => {
     return validationPatterns.envVarName.test(name);
   };
+
+  // Show JSON preview if requested
+  if (showJsonPreview) {
+    return (
+      <ServerJsonViewer
+        server={generatePreviewJson()}
+        serverId={formData.name || "new-server"}
+        onBack={handleBackFromJson}
+      />
+    );
+  }
 
   return (
     <div className="form-container">
@@ -385,15 +433,13 @@ const MasterServerForm = ({
           >
             Cancel
           </button>
-          {server && (
-            <button
-              type="button"
-              className="button button-info"
-              onClick={onViewJson}
-            >
-              View JSON
-            </button>
-          )}
+          <button
+            type="button"
+            className="button button-info"
+            onClick={handleViewJson}
+          >
+            View JSON
+          </button>
         </div>
       </form>
     </div>

--- a/src/components/MasterServerForm.jsx
+++ b/src/components/MasterServerForm.jsx
@@ -1,4 +1,10 @@
 import { useState, useEffect } from "react";
+import {
+  validateMcpServerConfig,
+  getValidationSummary,
+} from "../utils/validation/mcpValidator";
+import { ValidationBadge } from "./validation";
+import { validationPatterns } from "../utils/validation/mcpSchema";
 
 const MasterServerForm = ({
   server,
@@ -18,6 +24,10 @@ const MasterServerForm = ({
   const [newEnvKey, setNewEnvKey] = useState("");
   const [newEnvValue, setNewEnvValue] = useState("");
   const [originalId, setOriginalId] = useState("");
+
+  // Add state for validation
+  const [validationResult, setValidationResult] = useState(null);
+  const [showValidationDetails, setShowValidationDetails] = useState(false);
 
   // Initialize form data when server changes
   useEffect(() => {
@@ -42,6 +52,30 @@ const MasterServerForm = ({
       setOriginalId("");
     }
   }, [server, serverId]);
+
+  // Validate form data whenever it changes
+  useEffect(() => {
+    // Don't validate empty forms
+    if (
+      !formData.name &&
+      !formData.command &&
+      formData.args.length === 0 &&
+      Object.keys(formData.env).length === 0
+    ) {
+      setValidationResult(null);
+      return;
+    }
+
+    const result = validateMcpServerConfig(
+      formData,
+      formData.name || "Unnamed Server",
+    );
+    setValidationResult({
+      valid: result.errors.length === 0,
+      errors: result.errors,
+      warnings: result.warnings,
+    });
+  }, [formData]);
 
   // Handle input changes
   const handleChange = (e) => {
@@ -99,8 +133,6 @@ const MasterServerForm = ({
     });
   };
 
-  // UUID generation is now handled automatically by the backend
-
   // Handle form submission
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -118,16 +150,38 @@ const MasterServerForm = ({
     onSave(serverData);
   };
 
+  // Check if env var name is valid
+  const isValidEnvName = (name) => {
+    return validationPatterns.envVarName.test(name);
+  };
+
   return (
     <div className="form-container">
-      <h2>
-        {server ? "Edit Server in Master List" : "Add Server to Master List"}
-      </h2>
+      <div className="form-header">
+        <h2>
+          {server ? "Edit Server in Master List" : "Add Server to Master List"}
+        </h2>
+
+        {/* Add validation badge */}
+        {validationResult && (
+          <div className="form-validation">
+            <ValidationBadge
+              validationResult={validationResult}
+              showDetails={true}
+              onClick={() => setShowValidationDetails(!showValidationDetails)}
+            />
+            {validationResult && !validationResult.valid && (
+              <span className="validation-summary">
+                {getValidationSummary(validationResult)}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
 
       <form onSubmit={handleSubmit}>
         <div className="form-section">
           <h3>Basic Settings</h3>
-          {/* Server ID field removed - UUIDs are now generated automatically */}
           {originalId && (
             <div className="original-id-info">
               <small>Original ID: {originalId}</small>
@@ -157,7 +211,19 @@ const MasterServerForm = ({
               onChange={handleChange}
               placeholder="Command to run (e.g., npx, python)"
               required
+              className={
+                formData.command &&
+                !validationPatterns.safeCommand.test(formData.command)
+                  ? "input-warning"
+                  : ""
+              }
             />
+            {formData.command &&
+              !validationPatterns.safeCommand.test(formData.command) && (
+                <div className="input-message warning">
+                  Warning: Command contains potentially unsafe characters
+                </div>
+              )}
           </div>
         </div>
 
@@ -216,6 +282,9 @@ const MasterServerForm = ({
                 value={newEnvKey}
                 onChange={(e) => setNewEnvKey(e.target.value)}
                 placeholder="Variable name"
+                className={
+                  newEnvKey && !isValidEnvName(newEnvKey) ? "input-warning" : ""
+                }
                 onKeyDown={(e) => {
                   if (e.key === "Enter" && newEnvKey.trim()) {
                     e.preventDefault();
@@ -253,12 +322,28 @@ const MasterServerForm = ({
             </div>
           </div>
 
+          {newEnvKey && !isValidEnvName(newEnvKey) && (
+            <div className="input-message warning">
+              Warning: Environment variable name should contain only letters,
+              numbers, and underscores, and start with a letter or underscore
+            </div>
+          )}
+
           {Object.keys(formData.env).length > 0 && (
             <div className="env-vars-list">
               {Object.entries(formData.env).map(([key, value]) => (
                 <div key={key} className="env-var-item">
                   <div className="env-var-key">
-                    <code>{key}</code>
+                    <code
+                      className={!isValidEnvName(key) ? "env-var-warning" : ""}
+                      title={
+                        !isValidEnvName(key)
+                          ? "Variable name format warning"
+                          : ""
+                      }
+                    >
+                      {key}
+                    </code>
                   </div>
                   <div className="env-var-value">
                     <code>{value}</code>

--- a/src/components/MasterServerForm.jsx
+++ b/src/components/MasterServerForm.jsx
@@ -149,11 +149,12 @@ const MasterServerForm = ({
       serverData.originalId = formData.name;
     }
 
-    // Remove empty properties
-    if (formData.args && formData.args.length === 0) {
-      delete serverData.args;
+    // Ensure args is always an array (never delete it)
+    if (!serverData.args) {
+      serverData.args = [];
     }
 
+    // Remove empty env property if no environment variables
     if (formData.env && Object.keys(formData.env).length === 0) {
       delete serverData.env;
     }

--- a/src/components/MasterServerForm.jsx
+++ b/src/components/MasterServerForm.jsx
@@ -434,11 +434,11 @@ const MasterServerForm = ({
             Cancel
           </button>
           <button
-            type="button"
-            className="button button-info"
-            onClick={handleViewJson}
+          type="button"
+          className="button button-info"
+          onClick={handleViewJson}
           >
-            View JSON
+          Preview JSON
           </button>
         </div>
       </form>

--- a/src/components/MasterServerForm.jsx
+++ b/src/components/MasterServerForm.jsx
@@ -147,7 +147,14 @@ const MasterServerForm = ({
       serverData.originalId = formData.name;
     }
 
-    onSave(serverData);
+    // Call onSave with the server ID if we're editing an existing server
+    if (server && serverId) {
+      // We're updating an existing server
+      onSave(serverId, serverData);
+    } else {
+      // We're adding a new server
+      onSave(serverData);
+    }
   };
 
   // Check if env var name is valid

--- a/src/components/ProfileServerOverridesForm.jsx
+++ b/src/components/ProfileServerOverridesForm.jsx
@@ -22,6 +22,9 @@ const ProfileServerOverridesForm = ({
     env: {},
   });
 
+  // Track environment variables that should be removed
+  const [removedEnvVars, setRemovedEnvVars] = useState({});
+
   const [newArg, setNewArg] = useState("");
   const [newEnvKey, setNewEnvKey] = useState("");
   const [newEnvValue, setNewEnvValue] = useState("");
@@ -67,7 +70,10 @@ const ProfileServerOverridesForm = ({
           const newEnv = { ...(masterServer.env || {}) };
           Object.entries(profileServer.overrides.env).forEach(
             ([key, value]) => {
-              newEnv[key] = value;
+              // Skip null values which indicate deletion
+              if (value !== null) {
+                newEnv[key] = value;
+              }
             },
           );
 
@@ -75,9 +81,21 @@ const ProfileServerOverridesForm = ({
 
           const envOverrides = {};
           Object.keys(profileServer.overrides.env).forEach((key) => {
-            envOverrides[key] = true;
+            // If the value is not null, it's a normal override
+            if (profileServer.overrides.env[key] !== null) {
+              envOverrides[key] = true;
+            }
           });
           setOverrideFields((prev) => ({ ...prev, env: envOverrides }));
+          
+          // Track removed env vars
+          const removedVars = {};
+          Object.entries(profileServer.overrides.env).forEach(([key, value]) => {
+            if (value === null) {
+              removedVars[key] = true;
+            }
+          });
+          setRemovedEnvVars(removedVars);
         }
       }
     } else if (masterServer) {
@@ -96,6 +114,9 @@ const ProfileServerOverridesForm = ({
         args: false,
         env: {},
       });
+      
+      // No removed env vars
+      setRemovedEnvVars({});
     }
   }, [masterServer, profileServer]);
 
@@ -190,6 +211,15 @@ const ProfileServerOverridesForm = ({
   const handleAddEnvVar = () => {
     if (!newEnvKey.trim()) return;
 
+    // If this env var was previously removed, un-remove it
+    if (removedEnvVars[newEnvKey]) {
+      setRemovedEnvVars((prev) => {
+        const updated = { ...prev };
+        delete updated[newEnvKey];
+        return updated;
+      });
+    }
+
     setFormData((prev) => ({
       ...prev,
       env: {
@@ -213,6 +243,7 @@ const ProfileServerOverridesForm = ({
 
   // Handle removing an environment variable
   const handleRemoveEnvVar = (key) => {
+    // First, remove from form data
     setFormData((prev) => {
       const { [key]: removed, ...restEnv } = prev.env;
       return {
@@ -221,6 +252,15 @@ const ProfileServerOverridesForm = ({
       };
     });
 
+    // If this is a master server env var, mark it as removed in overrides
+    if (masterServer && masterServer.env && masterServer.env[key] !== undefined) {
+      setRemovedEnvVars(prev => ({
+        ...prev,
+        [key]: true
+      }));
+    }
+
+    // Always remove from override fields
     setOverrideFields((prev) => {
       const { [key]: removed, ...restEnvOverrides } = prev.env;
       return {
@@ -248,10 +288,17 @@ const ProfileServerOverridesForm = ({
 
     // Build env overrides
     const envOverrides = {};
+    
+    // Add normal env var overrides
     Object.entries(overrideFields.env).forEach(([key, isOverridden]) => {
       if (isOverridden && formData.env[key] !== undefined) {
         envOverrides[key] = formData.env[key];
       }
+    });
+    
+    // Add removal overrides (explicit null values)
+    Object.keys(removedEnvVars).forEach(key => {
+      envOverrides[key] = null; // Set to null to indicate deletion
     });
 
     if (Object.keys(envOverrides).length > 0) {
@@ -482,6 +529,46 @@ const ProfileServerOverridesForm = ({
                   </div>
                 </div>
               ))}
+            </div>
+          )}
+          
+          {/* Show removed env vars */}
+          {Object.keys(removedEnvVars).length > 0 && (
+            <div className="removed-env-vars">
+              <h4>Removed Environment Variables</h4>
+              <div className="removed-env-list">
+                {Object.keys(removedEnvVars).map(key => (
+                  <div key={key} className="removed-env-item">
+                    <code>{key}</code>
+                    <button
+                      type="button"
+                      className="button button-small"
+                      onClick={() => {
+                        // Restore this env var
+                        const masterValue = masterServer.env ? masterServer.env[key] : '';
+                        
+                        // Add back to form data
+                        setFormData(prev => ({
+                          ...prev,
+                          env: {
+                            ...prev.env,
+                            [key]: masterValue
+                          }
+                        }));
+                        
+                        // Remove from removed list
+                        setRemovedEnvVars(prev => {
+                          const updated = { ...prev };
+                          delete updated[key];
+                          return updated;
+                        });
+                      }}
+                    >
+                      Restore
+                    </button>
+                  </div>
+                ))}
+              </div>
             </div>
           )}
         </div>

--- a/src/components/ProfileServerOverridesForm.jsx
+++ b/src/components/ProfileServerOverridesForm.jsx
@@ -1,4 +1,6 @@
 import { useState, useEffect } from "react";
+import ServerJsonViewer from "./ServerJsonViewer";
+import { formatSingleServerConfig } from "../utils/validation/mcpValidator";
 
 const ProfileServerOverridesForm = ({
   serverId,
@@ -24,6 +26,7 @@ const ProfileServerOverridesForm = ({
 
   // Track environment variables that should be removed
   const [removedEnvVars, setRemovedEnvVars] = useState({});
+  const [showJsonPreview, setShowJsonPreview] = useState(false);
 
   const [newArg, setNewArg] = useState("");
   const [newEnvKey, setNewEnvKey] = useState("");
@@ -331,12 +334,80 @@ const ProfileServerOverridesForm = ({
     );
   }
 
+  // Generate preview JSON based on current form state and overrides
+  const generatePreviewJson = () => {
+    // Create a server object with the effective configuration
+    const effectiveServer = { ...masterServer };
+    
+    // Apply overrides from the form data based on which fields are being overridden
+    if (overrideFields.name) {
+      effectiveServer.name = formData.name;
+    }
+    
+    if (overrideFields.command) {
+      effectiveServer.command = formData.command;
+    }
+    
+    if (overrideFields.args) {
+      effectiveServer.args = [...formData.args];
+    }
+    
+    // Handle environment variables
+    effectiveServer.env = { ...masterServer.env };
+    
+    // Apply environment variable overrides
+    Object.entries(overrideFields.env).forEach(([key, isOverridden]) => {
+      if (isOverridden && formData.env[key] !== undefined) {
+        effectiveServer.env[key] = formData.env[key];
+      }
+    });
+    
+    // Remove deleted environment variables
+    Object.keys(removedEnvVars).forEach(key => {
+      delete effectiveServer.env[key];
+    });
+    
+    // If env is empty, remove it
+    if (effectiveServer.env && Object.keys(effectiveServer.env).length === 0) {
+      delete effectiveServer.env;
+    }
+    
+    return effectiveServer;
+  };
+
+  // Toggle JSON preview
+  const toggleJsonPreview = () => {
+    setShowJsonPreview(!showJsonPreview);
+  };
+
   return (
     <div className="form-container">
-      <h2>Customize Server for {profileName}</h2>
-      <p>Override specific settings from the Server Master List.</p>
+      <div className="form-header">
+        <div>
+          <h2>Customize Server for {profileName}</h2>
+          <p>Override specific settings from the Server Master List.</p>
+        </div>
+        <div className="form-actions">
+          <button 
+            type="button" 
+            className={`button ${showJsonPreview ? 'button-info' : 'button-secondary'}`}
+            onClick={toggleJsonPreview}
+          >
+            {showJsonPreview ? 'Hide JSON' : 'Preview JSON'}
+          </button>
+        </div>
+      </div>
 
-      <form onSubmit={handleSubmit}>
+      {showJsonPreview ? (
+        <div className="json-preview-container">
+          <ServerJsonViewer 
+            server={generatePreviewJson()} 
+            serverId={serverId}
+            onBack={toggleJsonPreview}
+          />
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit}>
         <div className="form-section">
           <h3>Basic Settings</h3>
 
@@ -586,6 +657,7 @@ const ProfileServerOverridesForm = ({
           </button>
         </div>
       </form>
+      )}
     </div>
   );
 };

--- a/src/components/ProfileServerOverridesForm.jsx
+++ b/src/components/ProfileServerOverridesForm.jsx
@@ -378,6 +378,7 @@ const ProfileServerOverridesForm = ({
         server={generatePreviewJson()} 
         serverId={serverId}
         onBack={handleBackFromJson}
+        profileName={profileName}
       />
     );
   }

--- a/src/components/ProfileServerOverridesForm.jsx
+++ b/src/components/ProfileServerOverridesForm.jsx
@@ -652,7 +652,7 @@ const ProfileServerOverridesForm = ({
             className="button button-info"
             onClick={handleViewJson}
           >
-            View JSON
+            Preview JSON
           </button>
         </div>
       </form>

--- a/src/components/ProfileServerOverridesForm.jsx
+++ b/src/components/ProfileServerOverridesForm.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
 import ServerJsonViewer from "./ServerJsonViewer";
-import { formatSingleServerConfig } from "../utils/validation/mcpValidator";
 
 const ProfileServerOverridesForm = ({
   serverId,
@@ -323,17 +322,6 @@ const ProfileServerOverridesForm = ({
     });
   };
 
-  if (!masterServer) {
-    return (
-      <div className="empty-state">
-        <p>Server not found in master list.</p>
-        <button className="button button-secondary" onClick={onCancel}>
-          Back
-        </button>
-      </div>
-    );
-  }
-
   // Generate preview JSON based on current form state and overrides
   const generatePreviewJson = () => {
     // Create a server object with the effective configuration
@@ -375,39 +363,42 @@ const ProfileServerOverridesForm = ({
     return effectiveServer;
   };
 
-  // Toggle JSON preview
-  const toggleJsonPreview = () => {
-    setShowJsonPreview(!showJsonPreview);
+  // Handle JSON preview
+  const handleViewJson = () => {
+    setShowJsonPreview(true);
   };
+
+  const handleBackFromJson = () => {
+    setShowJsonPreview(false);
+  };
+
+  if (showJsonPreview) {
+    return (
+      <ServerJsonViewer 
+        server={generatePreviewJson()} 
+        serverId={serverId}
+        onBack={handleBackFromJson}
+      />
+    );
+  }
+
+  if (!masterServer) {
+    return (
+      <div className="empty-state">
+        <p>Server not found in master list.</p>
+        <button className="button button-secondary" onClick={onCancel}>
+          Back
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div className="form-container">
-      <div className="form-header">
-        <div>
-          <h2>Customize Server for {profileName}</h2>
-          <p>Override specific settings from the Server Master List.</p>
-        </div>
-        <div className="form-actions">
-          <button 
-            type="button" 
-            className={`button ${showJsonPreview ? 'button-info' : 'button-secondary'}`}
-            onClick={toggleJsonPreview}
-          >
-            {showJsonPreview ? 'Hide JSON' : 'Preview JSON'}
-          </button>
-        </div>
-      </div>
+      <h2>Customize Server for {profileName}</h2>
+      <p>Override specific settings from the Server Master List.</p>
 
-      {showJsonPreview ? (
-        <div className="json-preview-container">
-          <ServerJsonViewer 
-            server={generatePreviewJson()} 
-            serverId={serverId}
-            onBack={toggleJsonPreview}
-          />
-        </div>
-      ) : (
-        <form onSubmit={handleSubmit}>
+      <form onSubmit={handleSubmit}>
         <div className="form-section">
           <h3>Basic Settings</h3>
 
@@ -655,9 +646,15 @@ const ProfileServerOverridesForm = ({
           >
             Cancel
           </button>
+          <button
+            type="button"
+            className="button button-info"
+            onClick={handleViewJson}
+          >
+            View JSON
+          </button>
         </div>
       </form>
-      )}
     </div>
   );
 };

--- a/src/components/ServerJsonViewer.css
+++ b/src/components/ServerJsonViewer.css
@@ -1,0 +1,79 @@
+.server-json-viewer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.server-json-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  border-bottom: 1px solid #edebe9;
+  background-color: #f8f8f8;
+}
+
+.server-json-title h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #323130;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.readonly-badge {
+  font-size: 0.8rem;
+  margin-left: 8px;
+  padding: 2px 6px;
+  background-color: #f3f2f1;
+  border-radius: 3px;
+  color: #605e5c;
+  font-weight: normal;
+}
+
+.server-json-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.button {
+  padding: 6px 12px;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid;
+  transition: all 0.2s ease;
+}
+
+.button-primary {
+  background-color: #0078d4;
+  color: white;
+  border-color: #0078d4;
+}
+
+.button-primary:hover {
+  background-color: #106ebe;
+  border-color: #106ebe;
+}
+
+.button-secondary {
+  background-color: #f3f2f1;
+  color: #323130;
+  border-color: #c8c6c4;
+}
+
+.button-secondary:hover {
+  background-color: #e1dfdd;
+  border-color: #b3b0ad;
+}
+
+/* Make JsonEditor fill the remaining space */
+.server-json-viewer .monaco-editor-container {
+  flex: 1;
+  min-height: 300px;
+  margin-top: 0;
+}

--- a/src/components/ServerJsonViewer.css
+++ b/src/components/ServerJsonViewer.css
@@ -4,6 +4,13 @@
   height: 100%;
 }
 
+.server-json-subtitle {
+  margin: 0;
+  font-size: 14px;
+  color: #666;
+  max-width: 600px;
+}
+
 .server-json-header {
   display: flex;
   justify-content: space-between;

--- a/src/components/ServerJsonViewer.jsx
+++ b/src/components/ServerJsonViewer.jsx
@@ -11,7 +11,7 @@ import "./ServerJsonViewer.css";
 /**
  * Component for viewing server configuration as JSON with validation
  */
-const ServerJsonViewer = ({ server, serverId, onBack, onUpdateServer }) => {
+const ServerJsonViewer = ({ server, serverId, onBack, onUpdateServer, profileName }) => {
   // State for validation and UI
   const [validationResult, setValidationResult] = useState(null);
   const [showValidationDetails, setShowValidationDetails] = useState(false);
@@ -65,9 +65,15 @@ const ServerJsonViewer = ({ server, serverId, onBack, onUpdateServer }) => {
       <div className="server-json-header">
         <div className="server-json-title">
           <h2>
-            MCP Configuration JSON - Server: {server.name}{" "}
+            {profileName 
+              ? `MCP Configuration JSON - Server: ${server.name} (Profile: ${profileName})` 
+              : `MCP Configuration JSON - Server: ${server.name}`}{" "}
             <span className="readonly-badge">🔒 Read-Only</span>
           </h2>
+          <p className="server-json-subtitle">
+            This view displays the selected server configuration in MCP-compliant format.
+            {profileName && ' All profile-specific overrides have been applied to the base configuration.'}
+          </p>
         </div>
 
         <div className="server-json-controls">
@@ -94,7 +100,14 @@ const ServerJsonViewer = ({ server, serverId, onBack, onUpdateServer }) => {
       )}
 
       {/* JSON Editor */}
-      <JsonEditor json={JSON.stringify(mcpJson, null, 2)} readOnly={true} />
+      <JsonEditor 
+        json={JSON.stringify(mcpJson, null, 2)} 
+        readOnly={true} 
+        serverName={server.name}
+        profileName={profileName}
+        isProfileView={false}
+        hideTitle={true}
+      />
     </div>
   );
 };

--- a/src/components/ServerJsonViewer.jsx
+++ b/src/components/ServerJsonViewer.jsx
@@ -1,27 +1,42 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import JsonEditor from "./JsonEditor";
 import { filterInternalFields } from "../utils/helpers";
+import {
+  validateMcpServerConfig,
+  formatSingleServerConfig,
+} from "../utils/validation/mcpValidator";
+import { ValidationBadge, ValidationDetails } from "./validation";
+import "./ServerJsonViewer.css";
 
-const ServerJsonViewer = ({ server, serverId, onBack }) => {
+/**
+ * Component for viewing server configuration as JSON with validation
+ */
+const ServerJsonViewer = ({ server, serverId, onBack, onUpdateServer }) => {
+  // State for validation and UI
+  const [validationResult, setValidationResult] = useState(null);
+  const [showValidationDetails, setShowValidationDetails] = useState(false);
+
   // Format server object for JSON display - filter out internal fields
-  let serverJson = filterInternalFields(server);
+  const serverJson = filterInternalFields(server);
 
-  // Format as an MCP compliant JSON structure
+  // Format as an MCP compliant JSON structure using the standard formatter
+  const serverFormatted = formatSingleServerConfig(serverJson);
   const mcpJson = {
-    [server.name || serverId]: {
-      command: serverJson.command,
-      args: serverJson.args,
-    },
+    [server.name || serverId]: serverFormatted,
   };
 
-  // Add environment variables if they exist
-  if (serverJson.env && Object.keys(serverJson.env).length > 0) {
-    mcpJson[server.name || serverId].env = serverJson.env;
-  }
-
-  // Automatically focus on the JSON content when the component mounts
+  // Validate the configuration when component mounts or server changes
   useEffect(() => {
-    // Set page title to indicate JSON view mode
+    const result = validateMcpServerConfig(serverJson, server.name || serverId);
+    setValidationResult({
+      valid: result.errors.length === 0,
+      errors: result.errors,
+      warnings: result.warnings,
+    });
+  }, [server, serverId]);
+
+  // Set page title to indicate JSON view mode
+  useEffect(() => {
     const originalTitle = document.title;
     document.title = `MCP Palette - JSON: ${server.name}`;
 
@@ -30,20 +45,55 @@ const ServerJsonViewer = ({ server, serverId, onBack }) => {
     };
   }, [server.name]);
 
+  // Handle applying suggested fixes
+  const handleApplyFix = (issue) => {
+    if (!issue.suggestion || !onUpdateServer) return;
+
+    // In a real implementation, this would apply the fix and update the server
+    // For now, we'll just log the suggestion
+    console.log("Would apply fix:", issue.suggestion);
+    alert("Fix application will be implemented in the next phase");
+  };
+
+  // Toggle validation details visibility
+  const toggleValidationDetails = () => {
+    setShowValidationDetails(!showValidationDetails);
+  };
+
   return (
     <div className="server-json-viewer">
       <div className="server-json-header">
-        <h2>
-          MCP Configuration JSON - Server: {server.name}{" "}
-          <span className="readonly-badge">🔒 Read-Only</span>
-        </h2>
-        <div className="server-json-actions">
+        <div className="server-json-title">
+          <h2>
+            MCP Configuration JSON - Server: {server.name}{" "}
+            <span className="readonly-badge">🔒 Read-Only</span>
+          </h2>
+        </div>
+
+        <div className="server-json-controls">
+          {/* Validation badge */}
+          <ValidationBadge
+            validationResult={validationResult}
+            showDetails={true}
+            onClick={toggleValidationDetails}
+          />
+
           <button className="button button-secondary" onClick={onBack}>
             Back to Form
           </button>
         </div>
       </div>
 
+      {/* Validation details panel */}
+      {showValidationDetails && validationResult && (
+        <ValidationDetails
+          validationResult={validationResult}
+          onApplyFix={handleApplyFix}
+          onClose={() => setShowValidationDetails(false)}
+        />
+      )}
+
+      {/* JSON Editor */}
       <JsonEditor json={JSON.stringify(mcpJson, null, 2)} readOnly={true} />
     </div>
   );

--- a/src/components/ServerMasterList.jsx
+++ b/src/components/ServerMasterList.jsx
@@ -90,32 +90,6 @@ const ServerMasterList = ({
                       action: () => onViewServerJson(serverId),
                       icon: "📑",
                     },
-                    {
-                      label: "Restore Defaults",
-                      action: async () => {
-                        const confirmed = await window.api.safeConfirm(
-                          `Restore default configuration for server "${serverName}"?`,
-                        );
-                        if (confirmed) {
-                          // Call restore function passed as prop
-                          onRestoreDefaults(serverId);
-                        }
-                      },
-                      icon: "🔄",
-                    },
-                    {
-                      label: "Delete Server",
-                      action: async () => {
-                        const confirmed = await window.api.safeConfirm(
-                          `Are you sure you want to delete the server "${serverName}"?`,
-                        );
-                        if (confirmed) {
-                          onDeleteServer(serverId);
-                        }
-                      },
-                      icon: "🗑️",
-                      type: "danger",
-                    },
                   ]}
                 />
               </div>

--- a/src/components/ServerMasterList.jsx
+++ b/src/components/ServerMasterList.jsx
@@ -86,7 +86,7 @@ const ServerMasterList = ({
                       icon: "📋",
                     },
                     {
-                      label: "View JSON",
+                      label: "Preview JSON",
                       action: () => onViewServerJson(serverId),
                       icon: "📑",
                     },

--- a/src/components/__tests__/MasterServerForm.test.jsx
+++ b/src/components/__tests__/MasterServerForm.test.jsx
@@ -1,0 +1,422 @@
+/**
+ * Tests for MasterServerForm component with validation integration
+ *
+ * These tests verify that the MasterServerForm correctly integrates
+ * with the validation system and displays validation feedback.
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import MasterServerForm from "../MasterServerForm";
+import * as mcpValidator from "../../utils/validation/mcpValidator";
+import { validationPatterns } from "../../utils/validation/mcpSchema";
+
+// Mock the validation components
+jest.mock("../validation", () => ({
+  ValidationBadge: ({ validationResult, onClick }) => (
+    <div
+      data-testid="validation-badge"
+      data-valid={validationResult?.valid}
+      data-errors={validationResult?.errors?.length}
+      data-warnings={validationResult?.warnings?.length}
+      onClick={onClick}
+    >
+      Validation Badge
+    </div>
+  ),
+}));
+
+describe("MasterServerForm", () => {
+  // Sample server data for testing
+  const serverData = {
+    name: "test-server",
+    command: "python",
+    args: ["-m", "server"],
+    env: {
+      PORT: "8000",
+      DEBUG: "true",
+    },
+    originalId: "test-server",
+  };
+
+  beforeEach(() => {
+    // Mock the validation functions
+    jest
+      .spyOn(mcpValidator, "validateMcpServerConfig")
+      .mockImplementation(() => ({
+        valid: true,
+        errors: [],
+        warnings: [],
+      }));
+
+    jest
+      .spyOn(mcpValidator, "getValidationSummary")
+      .mockImplementation(() => "Configuration is valid");
+
+    // Mock validation patterns
+    jest
+      .spyOn(validationPatterns, "safeCommand", "get")
+      .mockReturnValue(/^[^;&|<>$\\]*$/);
+    jest
+      .spyOn(validationPatterns, "envVarName", "get")
+      .mockReturnValue(/^[a-zA-Z_][a-zA-Z0-9_]*$/);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("renders with server data", () => {
+    render(
+      <MasterServerForm
+        server={serverData}
+        serverId="server-123"
+        onSave={() => {}}
+        onCancel={() => {}}
+        onViewJson={() => {}}
+      />,
+    );
+
+    // Should render the form with server data
+    expect(screen.getByDisplayValue("test-server")).toBeInTheDocument(); // name field
+    expect(screen.getByDisplayValue("python")).toBeInTheDocument(); // command field
+
+    // Should show args
+    expect(screen.getByText("-m")).toBeInTheDocument();
+    expect(screen.getByText("server")).toBeInTheDocument();
+
+    // Should show env vars
+    expect(screen.getByText("PORT")).toBeInTheDocument();
+    expect(screen.getByText("8000")).toBeInTheDocument();
+    expect(screen.getByText("DEBUG")).toBeInTheDocument();
+    expect(screen.getByText("true")).toBeInTheDocument();
+
+    // Should show original ID
+    expect(screen.getByText(/Original ID: test-server/)).toBeInTheDocument();
+  });
+
+  test("renders empty form for new server", () => {
+    render(<MasterServerForm onSave={() => {}} onCancel={() => {}} />);
+
+    // Should render empty form with default values
+    expect(screen.getByDisplayValue("")).toBeInTheDocument(); // empty name field
+    expect(screen.getByDisplayValue("npx")).toBeInTheDocument(); // default command
+
+    // Should not show any args or env vars
+    expect(screen.queryByText("PORT")).not.toBeInTheDocument();
+    expect(screen.queryByText("-m")).not.toBeInTheDocument();
+
+    // Should not show original ID
+    expect(screen.queryByText(/Original ID:/)).not.toBeInTheDocument();
+  });
+
+  test("validates form data as it changes", async () => {
+    render(
+      <MasterServerForm
+        server={serverData}
+        serverId="server-123"
+        onSave={() => {}}
+        onCancel={() => {}}
+        onViewJson={() => {}}
+      />,
+    );
+
+    // Mock validation to return warnings
+    mcpValidator.validateMcpServerConfig.mockImplementation(() => ({
+      valid: true,
+      errors: [],
+      warnings: [{ path: "command", message: "Potentially unsafe command" }],
+    }));
+
+    // Change the command field
+    const commandInput = screen.getByLabelText(/Command/);
+    fireEvent.change(commandInput, { target: { value: "python; rm -rf /" } });
+
+    // Should call validateMcpServerConfig with updated data
+    await waitFor(() => {
+      expect(mcpValidator.validateMcpServerConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ command: "python; rm -rf /" }),
+        expect.any(String),
+      );
+    });
+
+    // Should show validation badge with warnings
+    const badge = screen.getByTestId("validation-badge");
+    expect(badge).toBeInTheDocument();
+    expect(badge.dataset.warnings).toBe("1");
+  });
+
+  test("shows warning for unsafe command", async () => {
+    // Override the mock to use the actual pattern
+    validationPatterns.safeCommand.mockRestore();
+
+    render(
+      <MasterServerForm
+        server={serverData}
+        serverId="server-123"
+        onSave={() => {}}
+        onCancel={() => {}}
+        onViewJson={() => {}}
+      />,
+    );
+
+    // Change the command field to include unsafe characters
+    const commandInput = screen.getByLabelText(/Command/);
+    fireEvent.change(commandInput, { target: { value: "python; rm -rf /" } });
+
+    // Should show warning message
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /Warning: Command contains potentially unsafe characters/,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    // Command input should have warning class
+    expect(commandInput).toHaveClass("input-warning");
+  });
+
+  test("shows warning for invalid env variable name", async () => {
+    // Override the mock to use the actual pattern
+    validationPatterns.envVarName.mockRestore();
+
+    render(
+      <MasterServerForm
+        server={serverData}
+        serverId="server-123"
+        onSave={() => {}}
+        onCancel={() => {}}
+        onViewJson={() => {}}
+      />,
+    );
+
+    // Add an env var with invalid name
+    const envNameInput = screen.getByPlaceholderText("Variable name");
+    const envValueInput = screen.getByPlaceholderText("Value");
+    const addButton = screen.getByText("Add");
+
+    fireEvent.change(envNameInput, { target: { value: "123-invalid" } });
+    fireEvent.change(envValueInput, { target: { value: "test" } });
+
+    // Should show warning message
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Warning: Environment variable name should contain/),
+      ).toBeInTheDocument();
+    });
+
+    // Env name input should have warning class
+    expect(envNameInput).toHaveClass("input-warning");
+  });
+
+  test("handles adding arguments", () => {
+    render(
+      <MasterServerForm
+        server={serverData}
+        serverId="server-123"
+        onSave={() => {}}
+        onCancel={() => {}}
+        onViewJson={() => {}}
+      />,
+    );
+
+    // Add a new argument
+    const argInput = screen.getByPlaceholderText("Enter argument");
+    const addButton = screen.getAllByText("Add")[0]; // First "Add" button is for args
+
+    fireEvent.change(argInput, { target: { value: "--new-arg" } });
+    fireEvent.click(addButton);
+
+    // Should add the new argument to the list
+    expect(screen.getByText("--new-arg")).toBeInTheDocument();
+
+    // Should clear the input field
+    expect(argInput.value).toBe("");
+
+    // Should validate the updated form data
+    expect(mcpValidator.validateMcpServerConfig).toHaveBeenCalled();
+  });
+
+  test("handles removing arguments", () => {
+    render(
+      <MasterServerForm
+        server={serverData}
+        serverId="server-123"
+        onSave={() => {}}
+        onCancel={() => {}}
+        onViewJson={() => {}}
+      />,
+    );
+
+    // Should show existing args
+    expect(screen.getByText("-m")).toBeInTheDocument();
+
+    // Get the remove button for the first arg
+    const removeButtons = screen.getAllByText("Remove");
+    fireEvent.click(removeButtons[0]); // First "Remove" button is for the -m arg
+
+    // Should remove the argument
+    expect(screen.queryByText("-m")).not.toBeInTheDocument();
+
+    // Should validate the updated form data
+    expect(mcpValidator.validateMcpServerConfig).toHaveBeenCalled();
+  });
+
+  test("handles adding environment variables", () => {
+    render(
+      <MasterServerForm
+        server={serverData}
+        serverId="server-123"
+        onSave={() => {}}
+        onCancel={() => {}}
+        onViewJson={() => {}}
+      />,
+    );
+
+    // Add a new env var
+    const envNameInput = screen.getByPlaceholderText("Variable name");
+    const envValueInput = screen.getByPlaceholderText("Value");
+    const addButton = screen.getAllByText("Add")[1]; // Second "Add" button is for env vars
+
+    fireEvent.change(envNameInput, { target: { value: "NEW_VAR" } });
+    fireEvent.change(envValueInput, { target: { value: "new-value" } });
+    fireEvent.click(addButton);
+
+    // Should add the new env var to the list
+    expect(screen.getByText("NEW_VAR")).toBeInTheDocument();
+    expect(screen.getByText("new-value")).toBeInTheDocument();
+
+    // Should clear the input fields
+    expect(envNameInput.value).toBe("");
+    expect(envValueInput.value).toBe("");
+
+    // Should validate the updated form data
+    expect(mcpValidator.validateMcpServerConfig).toHaveBeenCalled();
+  });
+
+  test("handles removing environment variables", () => {
+    render(
+      <MasterServerForm
+        server={serverData}
+        serverId="server-123"
+        onSave={() => {}}
+        onCancel={() => {}}
+        onViewJson={() => {}}
+      />,
+    );
+
+    // Should show existing env vars
+    expect(screen.getByText("PORT")).toBeInTheDocument();
+
+    // Get the remove button for the PORT env var
+    const removeButtons = screen.getAllByText("Remove");
+    const portEnvVarRemoveButton = Array.from(removeButtons).find((button) =>
+      button.closest(".env-var-item")?.textContent.includes("PORT"),
+    );
+
+    fireEvent.click(portEnvVarRemoveButton);
+
+    // Should remove the env var
+    expect(screen.queryByText("PORT")).not.toBeInTheDocument();
+
+    // Should validate the updated form data
+    expect(mcpValidator.validateMcpServerConfig).toHaveBeenCalled();
+  });
+
+  test("calls onSave with form data when form is submitted", () => {
+    const mockSave = jest.fn();
+
+    render(
+      <MasterServerForm
+        server={serverData}
+        serverId="server-123"
+        onSave={mockSave}
+        onCancel={() => {}}
+        onViewJson={() => {}}
+      />,
+    );
+
+    // Make a change to the form
+    const nameInput = screen.getByLabelText(/Display Name/);
+    fireEvent.change(nameInput, { target: { value: "updated-name" } });
+
+    // Submit the form
+    const saveButton = screen.getByText("Save");
+    fireEvent.click(saveButton);
+
+    // Should call onSave with updated form data
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    expect(mockSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "updated-name",
+        command: "python",
+        args: ["-m", "server"],
+        env: { PORT: "8000", DEBUG: "true" },
+        originalId: "test-server",
+      }),
+    );
+  });
+
+  test("calls onCancel when cancel button is clicked", () => {
+    const mockCancel = jest.fn();
+
+    render(
+      <MasterServerForm
+        server={serverData}
+        serverId="server-123"
+        onSave={() => {}}
+        onCancel={mockCancel}
+        onViewJson={() => {}}
+      />,
+    );
+
+    // Click the cancel button
+    fireEvent.click(screen.getByText("Cancel"));
+
+    // Should call onCancel
+    expect(mockCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test("calls onViewJson when view JSON button is clicked", () => {
+    const mockViewJson = jest.fn();
+
+    render(
+      <MasterServerForm
+        server={serverData}
+        serverId="server-123"
+        onSave={() => {}}
+        onCancel={() => {}}
+        onViewJson={mockViewJson}
+      />,
+    );
+
+    // Click the view JSON button
+    fireEvent.click(screen.getByText("View JSON"));
+
+    // Should call onViewJson
+    expect(mockViewJson).toHaveBeenCalledTimes(1);
+  });
+
+  test("disables save button when required fields are empty", () => {
+    render(<MasterServerForm onSave={() => {}} onCancel={() => {}} />);
+
+    // Save button should be disabled initially because name is empty
+    const saveButton = screen.getByText("Save");
+    expect(saveButton).toBeDisabled();
+
+    // Fill in the name field
+    const nameInput = screen.getByLabelText(/Display Name/);
+    fireEvent.change(nameInput, { target: { value: "test-name" } });
+
+    // Save button should be enabled
+    expect(saveButton).not.toBeDisabled();
+
+    // Empty the command field
+    const commandInput = screen.getByLabelText(/Command/);
+    fireEvent.change(commandInput, { target: { value: "" } });
+
+    // Save button should be disabled again
+    expect(saveButton).toBeDisabled();
+  });
+});

--- a/src/components/__tests__/ServerJsonViewer.test.jsx
+++ b/src/components/__tests__/ServerJsonViewer.test.jsx
@@ -1,0 +1,287 @@
+/**
+ * Tests for ServerJsonViewer component with validation integration
+ *
+ * These tests verify that the ServerJsonViewer correctly integrates
+ * with the validation system and displays validation results.
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import ServerJsonViewer from "../ServerJsonViewer";
+import * as mcpValidator from "../../utils/validation/mcpValidator";
+
+// Mock the JsonEditor component since it's complex and not the focus of these tests
+jest.mock("../JsonEditor", () => {
+  return function MockJsonEditor({ json }) {
+    return <div data-testid="json-editor" data-json={json} />;
+  };
+});
+
+// Mock the validation components
+jest.mock("../validation", () => ({
+  ValidationBadge: ({ validationResult, onClick }) => (
+    <div
+      data-testid="validation-badge"
+      data-valid={validationResult?.valid}
+      data-errors={validationResult?.errors?.length}
+      data-warnings={validationResult?.warnings?.length}
+      onClick={onClick}
+    >
+      Validation Badge
+    </div>
+  ),
+  ValidationDetails: ({ validationResult, onApplyFix, onClose }) => (
+    <div
+      data-testid="validation-details"
+      data-valid={validationResult?.valid}
+      data-errors={validationResult?.errors?.length}
+      data-warnings={validationResult?.warnings?.length}
+    >
+      Validation Details
+      <button data-testid="close-details" onClick={onClose}>
+        Close
+      </button>
+      {validationResult?.errors?.map((error, i) => (
+        <div key={i} data-testid={`error-${i}`}>
+          {error.path}: {error.message}
+          {error.suggestion && (
+            <button
+              data-testid={`apply-fix-${i}`}
+              onClick={() => onApplyFix(error)}
+            >
+              Apply Fix
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+describe("ServerJsonViewer", () => {
+  // Sample server data for testing
+  const serverData = {
+    name: "test-server",
+    command: "python",
+    args: ["-m", "server"],
+    env: {
+      PORT: "8000",
+      DEBUG: "true",
+    },
+  };
+
+  beforeEach(() => {
+    // Mock the validation functions
+    jest
+      .spyOn(mcpValidator, "validateMcpServerConfig")
+      .mockImplementation(() => ({
+        errors: [
+          {
+            path: "command",
+            message: "Test error",
+            suggestion: { action: "fix" },
+          },
+        ],
+        warnings: [{ path: "env.PORT", message: "Test warning" }],
+      }));
+
+    jest
+      .spyOn(mcpValidator, "formatSingleServerConfig")
+      .mockImplementation((config) => ({ ...config }));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("renders with validation badge", () => {
+    render(
+      <ServerJsonViewer
+        server={serverData}
+        serverId="server-123"
+        onBack={() => {}}
+      />,
+    );
+
+    // Should render the ServerJsonViewer with title
+    expect(
+      screen.getByText(/MCP Configuration JSON - Server:/),
+    ).toBeInTheDocument();
+
+    // Should show the validation badge
+    const badge = screen.getByTestId("validation-badge");
+    expect(badge).toBeInTheDocument();
+
+    // Badge should have validation data
+    expect(badge.dataset.errors).toBe("1");
+    expect(badge.dataset.warnings).toBe("1");
+  });
+
+  test("shows validation details when badge is clicked", async () => {
+    render(
+      <ServerJsonViewer
+        server={serverData}
+        serverId="server-123"
+        onBack={() => {}}
+      />,
+    );
+
+    // Validation details should not be shown initially
+    expect(screen.queryByTestId("validation-details")).not.toBeInTheDocument();
+
+    // Click the validation badge
+    fireEvent.click(screen.getByTestId("validation-badge"));
+
+    // Validation details should now be shown
+    await waitFor(() => {
+      expect(screen.getByTestId("validation-details")).toBeInTheDocument();
+    });
+  });
+
+  test("hides validation details when close button is clicked", async () => {
+    render(
+      <ServerJsonViewer
+        server={serverData}
+        serverId="server-123"
+        onBack={() => {}}
+      />,
+    );
+
+    // Click the validation badge to show details
+    fireEvent.click(screen.getByTestId("validation-badge"));
+
+    // Validation details should be shown
+    await waitFor(() => {
+      expect(screen.getByTestId("validation-details")).toBeInTheDocument();
+    });
+
+    // Click the close button
+    fireEvent.click(screen.getByTestId("close-details"));
+
+    // Validation details should be hidden
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("validation-details"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test("handles applying fixes", async () => {
+    const mockUpdateServer = jest.fn();
+
+    render(
+      <ServerJsonViewer
+        server={serverData}
+        serverId="server-123"
+        onBack={() => {}}
+        onUpdateServer={mockUpdateServer}
+      />,
+    );
+
+    // Click the validation badge to show details
+    fireEvent.click(screen.getByTestId("validation-badge"));
+
+    // Validation details should be shown
+    await waitFor(() => {
+      expect(screen.getByTestId("validation-details")).toBeInTheDocument();
+    });
+
+    // Mock the auto-correction function
+    jest.spyOn(mcpValidator, "applyAutoCorrections").mockImplementation(() => ({
+      ...serverData,
+      command: "python-fixed",
+    }));
+
+    // Should show apply fix button
+    const applyFixButton = screen.getByTestId("apply-fix-0");
+    expect(applyFixButton).toBeInTheDocument();
+
+    // Click the apply fix button
+    fireEvent.click(applyFixButton);
+
+    // Should call the auto-correction function
+    expect(mcpValidator.applyAutoCorrections).toHaveBeenCalled();
+  });
+
+  test("displays formatted MCP JSON", () => {
+    render(
+      <ServerJsonViewer
+        server={serverData}
+        serverId="server-123"
+        onBack={() => {}}
+      />,
+    );
+
+    // Should call formatSingleServerConfig
+    expect(mcpValidator.formatSingleServerConfig).toHaveBeenCalledWith(
+      expect.any(Object),
+    );
+
+    // Should pass the formatted JSON to JsonEditor
+    const jsonEditor = screen.getByTestId("json-editor");
+    expect(jsonEditor).toBeInTheDocument();
+
+    // JSON should contain the server name
+    const jsonData = JSON.parse(jsonEditor.dataset.json);
+    expect(Object.keys(jsonData)[0]).toBe("test-server");
+  });
+
+  test("calls onBack when back button is clicked", () => {
+    const mockOnBack = jest.fn();
+
+    render(
+      <ServerJsonViewer
+        server={serverData}
+        serverId="server-123"
+        onBack={mockOnBack}
+      />,
+    );
+
+    // Click the back button
+    fireEvent.click(screen.getByText("Back to Form"));
+
+    // Should call onBack
+    expect(mockOnBack).toHaveBeenCalledTimes(1);
+  });
+
+  test("validates server data when it changes", async () => {
+    const { rerender } = render(
+      <ServerJsonViewer
+        server={serverData}
+        serverId="server-123"
+        onBack={() => {}}
+      />,
+    );
+
+    // Should have called validateMcpServerConfig
+    expect(mcpValidator.validateMcpServerConfig).toHaveBeenCalledTimes(1);
+
+    // Reset mock
+    mcpValidator.validateMcpServerConfig.mockClear();
+
+    // Update server data
+    const updatedServerData = {
+      ...serverData,
+      command: "node",
+      args: ["server.js"],
+    };
+
+    // Re-render with updated data
+    rerender(
+      <ServerJsonViewer
+        server={updatedServerData}
+        serverId="server-123"
+        onBack={() => {}}
+      />,
+    );
+
+    // Should have called validateMcpServerConfig again
+    expect(mcpValidator.validateMcpServerConfig).toHaveBeenCalledTimes(1);
+
+    // Should have been called with updated data
+    expect(mcpValidator.validateMcpServerConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ command: "node", args: ["server.js"] }),
+      expect.any(String),
+    );
+  });
+});

--- a/src/components/validation/ValidationBadge.css
+++ b/src/components/validation/ValidationBadge.css
@@ -1,16 +1,17 @@
 .validation-badge {
-  display: inline-flex;
+  display: inline-block;
   align-items: center;
-  padding: 4px 10px;
+  padding: 2px 6px;
   border-radius: 4px;
-  font-size: 0.9rem;
+  font-size: 12px;
   cursor: pointer;
   position: relative;
   user-select: none;
   margin-right: 8px;
-  font-weight: 600;
+  margin-left: 8px;
+  font-weight: bold;
   transition: background-color 0.2s ease;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  vertical-align: middle;
 }
 
 .validation-badge:hover {
@@ -18,33 +19,33 @@
 }
 
 .validation-badge-valid {
-  background-color: #dff6dd;
-  color: #107c10;
-  border: 1px solid #107c10;
+  background-color: #28a745;
+  color: white;
+  border: none;
 }
 
 .validation-badge-warning {
-  background-color: #fff4ce;
-  color: #9d5d00;
-  border: 1px solid #9d5d00;
+  background-color: #ffc107;
+  color: #212529;
+  border: none;
 }
 
 .validation-badge-error {
-  background-color: #fde7e9;
-  color: #c50f1f;
-  border: 1px solid #c50f1f;
+  background-color: #dc3545;
+  color: white;
+  border: none;
 }
 
 .validation-badge-unknown {
-  background-color: #f3f2f1;
-  color: #605e5c;
-  border: 1px solid #e1dfdd;
+  background-color: #6c757d;
+  color: white;
+  border: none;
 }
 
 .validation-badge-icon {
-  margin-right: 6px;
+  margin-right: 4px;
   font-weight: bold;
-  font-size: 1rem;
+  font-size: 14px;
 }
 
 .validation-details-popup {

--- a/src/components/validation/ValidationBadge.css
+++ b/src/components/validation/ValidationBadge.css
@@ -1,15 +1,16 @@
 .validation-badge {
   display: inline-flex;
   align-items: center;
-  padding: 4px 8px;
+  padding: 4px 10px;
   border-radius: 4px;
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   cursor: pointer;
   position: relative;
   user-select: none;
   margin-right: 8px;
-  font-weight: 500;
+  font-weight: 600;
   transition: background-color 0.2s ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 .validation-badge:hover {
@@ -19,19 +20,19 @@
 .validation-badge-valid {
   background-color: #dff6dd;
   color: #107c10;
-  border: 1px solid #a7e3a5;
+  border: 1px solid #107c10;
 }
 
 .validation-badge-warning {
   background-color: #fff4ce;
   color: #9d5d00;
-  border: 1px solid #f9e29e;
+  border: 1px solid #9d5d00;
 }
 
 .validation-badge-error {
   background-color: #fde7e9;
   color: #c50f1f;
-  border: 1px solid #f9c0c5;
+  border: 1px solid #c50f1f;
 }
 
 .validation-badge-unknown {
@@ -43,6 +44,7 @@
 .validation-badge-icon {
   margin-right: 6px;
   font-weight: bold;
+  font-size: 1rem;
 }
 
 .validation-details-popup {

--- a/src/components/validation/ValidationBadge.css
+++ b/src/components/validation/ValidationBadge.css
@@ -1,0 +1,134 @@
+.validation-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  position: relative;
+  user-select: none;
+  margin-right: 8px;
+  font-weight: 500;
+  transition: background-color 0.2s ease;
+}
+
+.validation-badge:hover {
+  filter: brightness(0.95);
+}
+
+.validation-badge-valid {
+  background-color: #dff6dd;
+  color: #107c10;
+  border: 1px solid #a7e3a5;
+}
+
+.validation-badge-warning {
+  background-color: #fff4ce;
+  color: #9d5d00;
+  border: 1px solid #f9e29e;
+}
+
+.validation-badge-error {
+  background-color: #fde7e9;
+  color: #c50f1f;
+  border: 1px solid #f9c0c5;
+}
+
+.validation-badge-unknown {
+  background-color: #f3f2f1;
+  color: #605e5c;
+  border: 1px solid #e1dfdd;
+}
+
+.validation-badge-icon {
+  margin-right: 6px;
+  font-weight: bold;
+}
+
+.validation-details-popup {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 1000;
+  width: 320px;
+  max-height: 400px;
+  overflow-y: auto;
+  background-color: white;
+  border: 1px solid #c8c6c4;
+  border-radius: 4px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  padding: 12px;
+  font-weight: normal;
+  color: #323130;
+  text-align: left;
+}
+
+.validation-details-popup::before {
+  content: "";
+  position: absolute;
+  top: -8px;
+  right: 20px;
+  width: 14px;
+  height: 14px;
+  background-color: white;
+  border-left: 1px solid #c8c6c4;
+  border-top: 1px solid #c8c6c4;
+  transform: rotate(45deg);
+}
+
+.validation-details-popup h4 {
+  margin-top: 0;
+  margin-bottom: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.validation-errors h4 {
+  color: #c50f1f;
+}
+
+.validation-warnings h4 {
+  color: #9d5d00;
+}
+
+.validation-details-popup ul {
+  padding-left: 16px;
+  margin: 0 0 12px 0;
+  list-style-type: disc;
+}
+
+.validation-error-item {
+  margin-bottom: 6px;
+  color: #c50f1f;
+  line-height: 1.4;
+}
+
+.validation-warning-item {
+  margin-bottom: 6px;
+  color: #9d5d00;
+  line-height: 1.4;
+}
+
+.validation-issue-path {
+  font-family: monospace;
+  font-size: 0.9em;
+  background-color: rgba(0, 0, 0, 0.05);
+  padding: 1px 3px;
+  border-radius: 2px;
+}
+
+.validation-more-item {
+  font-style: italic;
+  opacity: 0.8;
+  margin-top: 4px;
+}
+
+.validation-details-footer {
+  text-align: center;
+  margin-top: 8px;
+  font-size: 0.85rem;
+  color: #605e5c;
+  font-style: italic;
+  border-top: 1px solid #f3f2f1;
+  padding-top: 8px;
+}

--- a/src/components/validation/ValidationBadge.css
+++ b/src/components/validation/ValidationBadge.css
@@ -18,21 +18,10 @@
   filter: brightness(0.95);
 }
 
-.validation-badge-valid {
-  background-color: #28a745;
-  color: white;
-  border: none;
-}
-
+/* Only keep the warning badge style, others use global classes */
 .validation-badge-warning {
   background-color: #ffc107;
   color: #212529;
-  border: none;
-}
-
-.validation-badge-error {
-  background-color: #dc3545;
-  color: white;
   border: none;
 }
 

--- a/src/components/validation/ValidationBadge.jsx
+++ b/src/components/validation/ValidationBadge.jsx
@@ -1,0 +1,103 @@
+import React from "react";
+import "./ValidationBadge.css";
+
+/**
+ * A component that displays the validation status of a configuration
+ *
+ * @param {Object} validationResult - The validation result from mcpValidator
+ * @param {boolean} showDetails - Whether to show validation details on hover
+ * @param {Function} onClick - Click handler for the badge
+ */
+const ValidationBadge = ({
+  validationResult,
+  showDetails = false,
+  onClick,
+}) => {
+  // If no validation result, show "not validated" state
+  if (!validationResult) {
+    return (
+      <div
+        className="validation-badge validation-badge-unknown"
+        onClick={onClick}
+      >
+        <span className="validation-badge-icon">?</span>
+        <span className="validation-badge-text">Not validated</span>
+      </div>
+    );
+  }
+
+  const { valid, errors = [], warnings = [] } = validationResult;
+
+  // Determine badge type based on validation results
+  let badgeType = valid ? (warnings.length > 0 ? "warning" : "valid") : "error";
+
+  // Badge text and icon based on type
+  const badgeInfo = {
+    valid: { text: "Valid", icon: "✓" },
+    warning: { text: "Valid with warnings", icon: "⚠️" },
+    error: { text: "Invalid", icon: "✗" },
+  };
+
+  return (
+    <div
+      className={`validation-badge validation-badge-${badgeType}`}
+      onClick={onClick}
+    >
+      <span className="validation-badge-icon">{badgeInfo[badgeType].icon}</span>
+      <span className="validation-badge-text">{badgeInfo[badgeType].text}</span>
+
+      {showDetails && (badgeType === "warning" || badgeType === "error") && (
+        <div className="validation-details-popup">
+          {errors.length > 0 && (
+            <div className="validation-errors">
+              <h4>Errors ({errors.length})</h4>
+              <ul>
+                {errors.slice(0, 3).map((error, index) => (
+                  <li key={`error-${index}`} className="validation-error-item">
+                    <span className="validation-issue-path">{error.path}</span>:{" "}
+                    {error.message}
+                  </li>
+                ))}
+                {errors.length > 3 && (
+                  <li className="validation-more-item">
+                    ...and {errors.length - 3} more error(s)
+                  </li>
+                )}
+              </ul>
+            </div>
+          )}
+
+          {warnings.length > 0 && (
+            <div className="validation-warnings">
+              <h4>Warnings ({warnings.length})</h4>
+              <ul>
+                {warnings.slice(0, 3).map((warning, index) => (
+                  <li
+                    key={`warning-${index}`}
+                    className="validation-warning-item"
+                  >
+                    <span className="validation-issue-path">
+                      {warning.path}
+                    </span>
+                    : {warning.message}
+                  </li>
+                ))}
+                {warnings.length > 3 && (
+                  <li className="validation-more-item">
+                    ...and {warnings.length - 3} more warning(s)
+                  </li>
+                )}
+              </ul>
+            </div>
+          )}
+
+          <div className="validation-details-footer">
+            Click for full details
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ValidationBadge;

--- a/src/components/validation/ValidationBadge.jsx
+++ b/src/components/validation/ValidationBadge.jsx
@@ -28,8 +28,11 @@ const ValidationBadge = ({
 
   const { valid, errors = [], warnings = [] } = validationResult;
 
-  // Determine badge type based on validation results
+  // Determine badge type and CSS class
   let badgeType = valid ? (warnings.length > 0 ? "warning" : "valid") : "error";
+  let badgeClass = badgeType === "valid" ? "validation-success" : 
+                 badgeType === "error" ? "validation-error" : 
+                 `validation-badge-${badgeType}`;
 
   // Badge text and icon based on type
   const badgeInfo = {
@@ -40,7 +43,7 @@ const ValidationBadge = ({
 
   return (
     <div
-      className={`validation-badge validation-badge-${badgeType}`}
+      className={`validation-badge ${badgeClass}`}
       onClick={onClick}
     >
       <span className="validation-badge-icon">{badgeInfo[badgeType].icon}</span>

--- a/src/components/validation/ValidationBadge.jsx
+++ b/src/components/validation/ValidationBadge.jsx
@@ -33,9 +33,9 @@ const ValidationBadge = ({
 
   // Badge text and icon based on type
   const badgeInfo = {
-    valid: { text: "Valid", icon: "✓" },
-    warning: { text: "Valid with warnings", icon: "⚠️" },
-    error: { text: "Invalid", icon: "✗" },
+    valid: { text: "Valid", icon: "✔" },
+    warning: { text: "Valid with warnings", icon: "⚠" },
+    error: { text: "Invalid", icon: "✘" },
   };
 
   return (
@@ -44,7 +44,7 @@ const ValidationBadge = ({
       onClick={onClick}
     >
       <span className="validation-badge-icon">{badgeInfo[badgeType].icon}</span>
-      <span className="validation-badge-text">{badgeInfo[badgeType].text}</span>
+      {badgeInfo[badgeType].text}
 
       {showDetails && (badgeType === "warning" || badgeType === "error") && (
         <div className="validation-details-popup">

--- a/src/components/validation/ValidationDetails.css
+++ b/src/components/validation/ValidationDetails.css
@@ -1,0 +1,195 @@
+.validation-details-container {
+  margin-bottom: 16px;
+  background-color: white;
+  border: 1px solid #edebe9;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+}
+
+.validation-details-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  background-color: #f8f8f8;
+  border-bottom: 1px solid #edebe9;
+}
+
+.validation-details-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #323130;
+}
+
+.validation-details-close {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  color: #605e5c;
+  cursor: pointer;
+  padding: 0 6px;
+}
+
+.validation-details-close:hover {
+  color: #323130;
+}
+
+.validation-details-tabs {
+  display: flex;
+  border-bottom: 1px solid #edebe9;
+  background-color: #fafafa;
+}
+
+.validation-tab {
+  padding: 10px 16px;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #605e5c;
+  transition: all 0.2s ease;
+}
+
+.validation-tab:hover {
+  background-color: rgba(0, 0, 0, 0.03);
+  color: #323130;
+}
+
+.validation-tab.active {
+  color: #0078d4;
+  border-bottom-color: #0078d4;
+  font-weight: 600;
+}
+
+.validation-details-content {
+  padding: 16px;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.validation-details-empty {
+  padding: 24px 16px;
+  text-align: center;
+  color: #107c10;
+}
+
+.validation-no-issues {
+  text-align: center;
+  color: #605e5c;
+  font-style: italic;
+  padding: 16px 0;
+}
+
+.validation-section {
+  margin-bottom: 20px;
+}
+
+.validation-section:last-child {
+  margin-bottom: 0;
+}
+
+.validation-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.validation-table th,
+.validation-table td {
+  padding: 8px;
+  text-align: left;
+  border-bottom: 1px solid #edebe9;
+}
+
+.validation-table th {
+  font-weight: 600;
+  background-color: #f5f5f5;
+  color: #323130;
+}
+
+.validation-error-row {
+  background-color: #fef5f5;
+}
+
+.validation-error-row:hover {
+  background-color: #fee7e7;
+}
+
+.validation-warning-row {
+  background-color: #fffcf5;
+}
+
+.validation-warning-row:hover {
+  background-color: #fff8e6;
+}
+
+.validation-path {
+  font-family: monospace;
+  white-space: nowrap;
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  background-color: rgba(0, 0, 0, 0.03);
+  padding: 2px 4px;
+  border-radius: 3px;
+  font-size: 0.85em;
+}
+
+.validation-actions {
+  text-align: right;
+  width: 80px;
+}
+
+.button-small {
+  padding: 2px 8px;
+  font-size: 0.8rem;
+  border-radius: 3px;
+  border: 1px solid;
+  cursor: pointer;
+  font-weight: 500;
+  background-color: #0078d4;
+  border-color: #0078d4;
+  color: white;
+}
+
+.button-small:hover {
+  background-color: #106ebe;
+  border-color: #106ebe;
+}
+
+.button-small.button-secondary {
+  background-color: #f3f2f1;
+  border-color: #c8c6c4;
+  color: #323130;
+}
+
+.button-small.button-secondary:hover {
+  background-color: #e1dfdd;
+  border-color: #b3b0ad;
+}
+
+.validation-details-footer {
+  padding: 12px 16px;
+  background-color: #f8f8f8;
+  border-top: 1px solid #edebe9;
+  font-size: 0.9rem;
+}
+
+.validation-summary {
+  margin-bottom: 8px;
+  font-weight: 500;
+}
+
+.validation-help {
+  color: #605e5c;
+  font-size: 0.85rem;
+}
+
+.validation-help p {
+  margin: 0;
+}

--- a/src/components/validation/ValidationDetails.jsx
+++ b/src/components/validation/ValidationDetails.jsx
@@ -1,0 +1,170 @@
+import React, { useState } from "react";
+import "./ValidationDetails.css";
+
+/**
+ * A component that displays detailed validation information
+ *
+ * @param {Object} validationResult - The validation result from mcpValidator
+ * @param {Function} onApplyFix - Handler for applying suggested fixes
+ * @param {Function} onClose - Handler for closing the details view
+ */
+const ValidationDetails = ({ validationResult, onApplyFix, onClose }) => {
+  const [tab, setTab] = useState("errors");
+  const { errors = [], warnings = [] } = validationResult || {};
+
+  // If no validation result or no issues, show empty state
+  if (!validationResult || (errors.length === 0 && warnings.length === 0)) {
+    return (
+      <div className="validation-details-container">
+        <div className="validation-details-header">
+          <h3>Validation Results</h3>
+          {onClose && (
+            <button className="validation-details-close" onClick={onClose}>
+              &times;
+            </button>
+          )}
+        </div>
+        <div className="validation-details-empty">
+          <p>No validation issues found. Configuration is valid.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="validation-details-container">
+      <div className="validation-details-header">
+        <h3>Validation Results</h3>
+        {onClose && (
+          <button className="validation-details-close" onClick={onClose}>
+            &times;
+          </button>
+        )}
+      </div>
+
+      <div className="validation-details-tabs">
+        <button
+          className={`validation-tab ${tab === "errors" ? "active" : ""}`}
+          onClick={() => setTab("errors")}
+        >
+          Errors ({errors.length})
+        </button>
+        <button
+          className={`validation-tab ${tab === "warnings" ? "active" : ""}`}
+          onClick={() => setTab("warnings")}
+        >
+          Warnings ({warnings.length})
+        </button>
+      </div>
+
+      <div className="validation-details-content">
+        {tab === "errors" && (
+          <div className="validation-section validation-errors-section">
+            {errors.length === 0 ? (
+              <p className="validation-no-issues">No errors found.</p>
+            ) : (
+              <table className="validation-table">
+                <thead>
+                  <tr>
+                    <th>Path</th>
+                    <th>Issue</th>
+                    <th>Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {errors.map((error, index) => (
+                    <tr key={`error-${index}`} className="validation-error-row">
+                      <td className="validation-path">
+                        {error.path || "<root>"}
+                      </td>
+                      <td>{error.message}</td>
+                      <td className="validation-actions">
+                        {error.suggestion && (
+                          <button
+                            className="button button-small"
+                            onClick={() => onApplyFix(error)}
+                            title={
+                              error.suggestion.description ||
+                              "Apply suggested fix"
+                            }
+                          >
+                            Fix
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        )}
+
+        {tab === "warnings" && (
+          <div className="validation-section validation-warnings-section">
+            {warnings.length === 0 ? (
+              <p className="validation-no-issues">No warnings found.</p>
+            ) : (
+              <table className="validation-table">
+                <thead>
+                  <tr>
+                    <th>Path</th>
+                    <th>Issue</th>
+                    <th>Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {warnings.map((warning, index) => (
+                    <tr
+                      key={`warning-${index}`}
+                      className="validation-warning-row"
+                    >
+                      <td className="validation-path">
+                        {warning.path || "<root>"}
+                      </td>
+                      <td>{warning.message}</td>
+                      <td className="validation-actions">
+                        {warning.suggestion && (
+                          <button
+                            className="button button-small button-secondary"
+                            onClick={() => onApplyFix(warning)}
+                            title={
+                              warning.suggestion.description ||
+                              "Apply suggested fix"
+                            }
+                          >
+                            Fix
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Footer with helpful information */}
+      <div className="validation-details-footer">
+        <div className="validation-summary">
+          <p>
+            {validationResult.valid
+              ? "Configuration is valid" +
+                (warnings.length > 0 ? " with warnings" : "")
+              : "Configuration has validation errors"}
+          </p>
+        </div>
+        <div className="validation-help">
+          <p>
+            <strong>Note:</strong> Errors must be fixed for MCP compliance.
+            Warnings are suggestions for best practices.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ValidationDetails;

--- a/src/components/validation/__tests__/ValidationBadge.test.jsx
+++ b/src/components/validation/__tests__/ValidationBadge.test.jsx
@@ -27,7 +27,7 @@ describe("ValidationBadge", () => {
     render(<ValidationBadge validationResult={validResult} />);
 
     expect(screen.getByText("Valid")).toBeInTheDocument();
-    expect(screen.getByText("✓")).toBeInTheDocument();
+    expect(screen.getByText("✔")).toBeInTheDocument();
 
     // Badge should have valid class
     const badge = screen.getByText("Valid").closest(".validation-badge");
@@ -44,7 +44,7 @@ describe("ValidationBadge", () => {
     render(<ValidationBadge validationResult={validWithWarningsResult} />);
 
     expect(screen.getByText("Valid with warnings")).toBeInTheDocument();
-    expect(screen.getByText("⚠️")).toBeInTheDocument();
+    expect(screen.getByText("⚠")).toBeInTheDocument();
 
     // Badge should have warning class
     const badge = screen
@@ -63,7 +63,7 @@ describe("ValidationBadge", () => {
     render(<ValidationBadge validationResult={invalidResult} />);
 
     expect(screen.getByText("Invalid")).toBeInTheDocument();
-    expect(screen.getByText("✗")).toBeInTheDocument();
+    expect(screen.getByText("✘")).toBeInTheDocument();
 
     // Badge should have error class
     const badge = screen.getByText("Invalid").closest(".validation-badge");

--- a/src/components/validation/__tests__/ValidationBadge.test.jsx
+++ b/src/components/validation/__tests__/ValidationBadge.test.jsx
@@ -31,7 +31,7 @@ describe("ValidationBadge", () => {
 
     // Badge should have valid class
     const badge = screen.getByText("Valid").closest(".validation-badge");
-    expect(badge).toHaveClass("validation-badge-valid");
+    expect(badge).toHaveClass("validation-success");
   });
 
   test('renders "valid with warnings" state for valid result with warnings', () => {
@@ -67,7 +67,7 @@ describe("ValidationBadge", () => {
 
     // Badge should have error class
     const badge = screen.getByText("Invalid").closest(".validation-badge");
-    expect(badge).toHaveClass("validation-badge-error");
+    expect(badge).toHaveClass("validation-error");
   });
 
   test("shows details popup when showDetails is true and has warnings/errors", () => {

--- a/src/components/validation/__tests__/ValidationBadge.test.jsx
+++ b/src/components/validation/__tests__/ValidationBadge.test.jsx
@@ -1,0 +1,144 @@
+/**
+ * Tests for ValidationBadge component
+ *
+ * These tests verify the behavior of the ValidationBadge component
+ * under different validation result scenarios.
+ */
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ValidationBadge from "../ValidationBadge";
+
+describe("ValidationBadge", () => {
+  test('renders "not validated" state when no validation result provided', () => {
+    render(<ValidationBadge validationResult={null} />);
+
+    expect(screen.getByText("Not validated")).toBeInTheDocument();
+    expect(screen.getByText("?")).toBeInTheDocument();
+  });
+
+  test('renders "valid" state for valid result with no warnings', () => {
+    const validResult = {
+      valid: true,
+      errors: [],
+      warnings: [],
+    };
+
+    render(<ValidationBadge validationResult={validResult} />);
+
+    expect(screen.getByText("Valid")).toBeInTheDocument();
+    expect(screen.getByText("✓")).toBeInTheDocument();
+
+    // Badge should have valid class
+    const badge = screen.getByText("Valid").closest(".validation-badge");
+    expect(badge).toHaveClass("validation-badge-valid");
+  });
+
+  test('renders "valid with warnings" state for valid result with warnings', () => {
+    const validWithWarningsResult = {
+      valid: true,
+      errors: [],
+      warnings: [{ path: "command", message: "Potentially unsafe command" }],
+    };
+
+    render(<ValidationBadge validationResult={validWithWarningsResult} />);
+
+    expect(screen.getByText("Valid with warnings")).toBeInTheDocument();
+    expect(screen.getByText("⚠️")).toBeInTheDocument();
+
+    // Badge should have warning class
+    const badge = screen
+      .getByText("Valid with warnings")
+      .closest(".validation-badge");
+    expect(badge).toHaveClass("validation-badge-warning");
+  });
+
+  test('renders "invalid" state for invalid result', () => {
+    const invalidResult = {
+      valid: false,
+      errors: [{ path: "command", message: "Missing command property" }],
+      warnings: [],
+    };
+
+    render(<ValidationBadge validationResult={invalidResult} />);
+
+    expect(screen.getByText("Invalid")).toBeInTheDocument();
+    expect(screen.getByText("✗")).toBeInTheDocument();
+
+    // Badge should have error class
+    const badge = screen.getByText("Invalid").closest(".validation-badge");
+    expect(badge).toHaveClass("validation-badge-error");
+  });
+
+  test("shows details popup when showDetails is true and has warnings/errors", () => {
+    const invalidResult = {
+      valid: false,
+      errors: [{ path: "command", message: "Missing command property" }],
+      warnings: [{ path: "env.PORT", message: "Invalid variable name" }],
+    };
+
+    render(
+      <ValidationBadge validationResult={invalidResult} showDetails={true} />,
+    );
+
+    // Should show error and warning in popup
+    expect(screen.getByText("Errors (1)")).toBeInTheDocument();
+    expect(screen.getByText(/Missing command property/)).toBeInTheDocument();
+    expect(screen.getByText("Warnings (1)")).toBeInTheDocument();
+    expect(screen.getByText(/Invalid variable name/)).toBeInTheDocument();
+  });
+
+  test("truncates long error/warning lists in details popup", () => {
+    const invalidResult = {
+      valid: false,
+      errors: Array(5)
+        .fill(0)
+        .map((_, i) => ({
+          path: `error${i}`,
+          message: `Error message ${i}`,
+        })),
+      warnings: Array(5)
+        .fill(0)
+        .map((_, i) => ({
+          path: `warning${i}`,
+          message: `Warning message ${i}`,
+        })),
+    };
+
+    render(
+      <ValidationBadge validationResult={invalidResult} showDetails={true} />,
+    );
+
+    // Should show first 3 errors/warnings and a "more" message
+    expect(screen.getByText("Errors (5)")).toBeInTheDocument();
+    expect(screen.getByText(/Error message 0/)).toBeInTheDocument();
+    expect(screen.getByText(/Error message 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Error message 2/)).toBeInTheDocument();
+    expect(screen.getByText(/...and 2 more error/)).toBeInTheDocument();
+
+    expect(screen.getByText("Warnings (5)")).toBeInTheDocument();
+    expect(screen.getByText(/Warning message 0/)).toBeInTheDocument();
+    expect(screen.getByText(/Warning message 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Warning message 2/)).toBeInTheDocument();
+    expect(screen.getByText(/...and 2 more warning/)).toBeInTheDocument();
+  });
+
+  test("calls onClick handler when clicked", () => {
+    const mockOnClick = jest.fn();
+    const validResult = {
+      valid: true,
+      errors: [],
+      warnings: [],
+    };
+
+    render(
+      <ValidationBadge validationResult={validResult} onClick={mockOnClick} />,
+    );
+
+    // Click the badge
+    fireEvent.click(screen.getByText("Valid"));
+
+    // Should have called the onClick handler
+    expect(mockOnClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/validation/__tests__/ValidationDetails.test.jsx
+++ b/src/components/validation/__tests__/ValidationDetails.test.jsx
@@ -1,0 +1,193 @@
+/**
+ * Tests for ValidationDetails component
+ *
+ * These tests verify the behavior of the ValidationDetails component
+ * under different validation result scenarios.
+ */
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ValidationDetails from "../ValidationDetails";
+
+describe("ValidationDetails", () => {
+  test("renders empty state when no validation issues found", () => {
+    const validResult = {
+      valid: true,
+      errors: [],
+      warnings: [],
+    };
+
+    render(<ValidationDetails validationResult={validResult} />);
+
+    expect(
+      screen.getByText("No validation issues found. Configuration is valid."),
+    ).toBeInTheDocument();
+  });
+
+  test("renders empty state when validation result is null", () => {
+    render(<ValidationDetails validationResult={null} />);
+
+    expect(screen.getByText("No validation issues found.")).toBeInTheDocument();
+  });
+
+  test("renders validation errors", () => {
+    const invalidResult = {
+      valid: false,
+      errors: [
+        { path: "command", message: "Missing command property" },
+        { path: "args", message: "args must be an array" },
+      ],
+      warnings: [],
+    };
+
+    render(<ValidationDetails validationResult={invalidResult} />);
+
+    // Should show error tab by default
+    expect(screen.getByText("Errors (2)")).toBeInTheDocument();
+
+    // Should show both errors
+    expect(screen.getByText("command")).toBeInTheDocument();
+    expect(screen.getByText("Missing command property")).toBeInTheDocument();
+    expect(screen.getByText("args")).toBeInTheDocument();
+    expect(screen.getByText("args must be an array")).toBeInTheDocument();
+  });
+
+  test("renders validation warnings", () => {
+    const warningResult = {
+      valid: true,
+      errors: [],
+      warnings: [
+        { path: "command", message: "Potentially unsafe command" },
+        { path: "env.PORT", message: "Invalid variable name" },
+      ],
+    };
+
+    render(<ValidationDetails validationResult={warningResult} />);
+
+    // Switch to warnings tab
+    fireEvent.click(screen.getByText("Warnings (2)"));
+
+    // Should show both warnings
+    expect(screen.getByText("command")).toBeInTheDocument();
+    expect(screen.getByText("Potentially unsafe command")).toBeInTheDocument();
+    expect(screen.getByText("env.PORT")).toBeInTheDocument();
+    expect(screen.getByText("Invalid variable name")).toBeInTheDocument();
+  });
+
+  test("allows switching between errors and warnings tabs", () => {
+    const result = {
+      valid: false,
+      errors: [{ path: "command", message: "Missing command" }],
+      warnings: [{ path: "env.PORT", message: "Invalid variable name" }],
+    };
+
+    render(<ValidationDetails validationResult={result} />);
+
+    // Should start with errors tab
+    expect(screen.getByText("Errors (1)")).toBeInTheDocument();
+    expect(screen.getByText("Missing command")).toBeInTheDocument();
+
+    // Switch to warnings tab
+    fireEvent.click(screen.getByText("Warnings (1)"));
+
+    // Should show warnings
+    expect(screen.getByText("Invalid variable name")).toBeInTheDocument();
+
+    // Switch back to errors tab
+    fireEvent.click(screen.getByText("Errors (1)"));
+
+    // Should show errors again
+    expect(screen.getByText("Missing command")).toBeInTheDocument();
+  });
+
+  test("renders fix buttons for issues with suggestions", () => {
+    const result = {
+      valid: false,
+      errors: [
+        {
+          path: "command",
+          message: "Missing command property",
+          suggestion: {
+            action: "add",
+            value: "python",
+            description: "Add a command",
+          },
+        },
+        {
+          path: "args",
+          message: "args must be an array",
+          // No suggestion
+        },
+      ],
+      warnings: [],
+    };
+
+    render(<ValidationDetails validationResult={result} />);
+
+    // Should have one fix button for the issue with a suggestion
+    const fixButtons = screen.getAllByText("Fix");
+    expect(fixButtons).toHaveLength(1);
+  });
+
+  test("calls onApplyFix when fix button is clicked", () => {
+    const mockApplyFix = jest.fn();
+    const issue = {
+      path: "command",
+      message: "Missing command property",
+      suggestion: {
+        action: "add",
+        value: "python",
+        description: "Add a command",
+      },
+    };
+
+    const result = {
+      valid: false,
+      errors: [issue],
+      warnings: [],
+    };
+
+    render(
+      <ValidationDetails validationResult={result} onApplyFix={mockApplyFix} />,
+    );
+
+    // Click the fix button
+    fireEvent.click(screen.getByText("Fix"));
+
+    // Should call onApplyFix with the issue
+    expect(mockApplyFix).toHaveBeenCalledTimes(1);
+    expect(mockApplyFix).toHaveBeenCalledWith(issue);
+  });
+
+  test("calls onClose when close button is clicked", () => {
+    const mockClose = jest.fn();
+    const result = {
+      valid: true,
+      errors: [],
+      warnings: [],
+    };
+
+    render(<ValidationDetails validationResult={result} onClose={mockClose} />);
+
+    // Click the close button
+    fireEvent.click(screen.getByText("×"));
+
+    // Should call onClose
+    expect(mockClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("renders validation summary in footer", () => {
+    const invalidResult = {
+      valid: false,
+      errors: [{ path: "command", message: "Missing command" }],
+      warnings: [{ path: "env.PORT", message: "Invalid variable name" }],
+    };
+
+    render(<ValidationDetails validationResult={invalidResult} />);
+
+    // Should show summary in footer
+    expect(
+      screen.getByText("Configuration has validation errors"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/validation/index.js
+++ b/src/components/validation/index.js
@@ -1,0 +1,7 @@
+/**
+ * Validation Components
+ * Export all validation-related components for easier imports
+ */
+
+export { default as ValidationBadge } from "./ValidationBadge";
+export { default as ValidationDetails } from "./ValidationDetails";

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,36 @@
+// This file is run before each test file
+import "@testing-library/jest-dom";
+
+// Mock window.api functions used in components
+window.api = {
+  getServerMasterList: jest.fn().mockResolvedValue({}),
+  getProfiles: jest.fn().mockResolvedValue([]),
+  getActiveProfile: jest.fn().mockResolvedValue(""),
+  setActiveProfile: jest.fn().mockResolvedValue(true),
+  addProfile: jest.fn().mockResolvedValue([]),
+  updateProfile: jest.fn().mockResolvedValue([]),
+  deleteProfile: jest.fn().mockResolvedValue([]),
+  renameProfile: jest.fn().mockResolvedValue([]),
+  addMasterServer: jest.fn().mockResolvedValue({}),
+  updateMasterServer: jest.fn().mockResolvedValue({}),
+  deleteMasterServer: jest.fn().mockResolvedValue({}),
+  safeAlert: jest.fn().mockResolvedValue(undefined),
+  safeConfirm: jest.fn().mockResolvedValue(true),
+  importConfig: jest.fn().mockResolvedValue({}),
+  exportConfig: jest.fn().mockResolvedValue(true),
+  onProfilesUpdated: jest.fn(),
+  onProfilesReset: jest.fn(),
+  onMenuImportConfig: jest.fn(),
+  onMenuExportConfig: jest.fn(),
+  removeAllListeners: jest.fn(),
+};
+
+// Mock resize observer
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}));
+
+// Suppress console errors during tests
+console.error = jest.fn();

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -428,6 +428,21 @@ body {
   margin: 0 auto;
 }
 
+.form-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 20px;
+}
+
+.json-preview-container {
+  margin-top: 10px;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  background-color: #f9f9f9;
+  overflow: hidden;
+}
+
 .form-section {
   margin-bottom: 20px;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -428,13 +428,6 @@ body {
   margin: 0 auto;
 }
 
-.form-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  margin-bottom: 20px;
-}
-
 .json-preview-container {
   margin-top: 10px;
   border: 1px solid #e0e0e0;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,10 +1,10 @@
 /* Validation badges */
-.validation-badge {
+.validation-badge, .validation-success, .validation-error {
   display: inline-block;
   padding: 2px 6px;
   margin-left: 10px;
   font-size: 12px;
-  font-weight: normal;
+  font-weight: bold;
   color: white;
   border-radius: 4px;
   vertical-align: middle;
@@ -90,7 +90,7 @@
   padding: 2px 6px;
   margin-left: 10px;
   font-size: 12px;
-  font-weight: normal;
+  font-weight: bold;
   color: white;
   background-color: #6c757d;
   border-radius: 4px;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,3 +1,46 @@
+/* Validation badges */
+.validation-badge {
+  display: inline-block;
+  padding: 2px 6px;
+  margin-left: 10px;
+  font-size: 12px;
+  font-weight: normal;
+  color: white;
+  border-radius: 4px;
+  vertical-align: middle;
+}
+
+.validation-success {
+  background-color: #28a745;
+}
+
+.validation-error {
+  background-color: #dc3545;
+}
+
+.json-editor-validation-errors {
+  padding: 10px;
+  margin-bottom: 10px;
+  background-color: #fff3f3;
+  border: 1px solid #ffcccc;
+  color: #dc3545;
+  border-radius: 4px;
+}
+
+.json-editor-validation-errors h3 {
+  margin-top: 0;
+  font-size: 16px;
+  margin-bottom: 8px;
+}
+
+.json-editor-validation-errors ul {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.json-editor-validation-errors li {
+  margin-bottom: 4px;
+}
 /* Server list header */
 .server-list-header {
   display: flex;

--- a/src/styles/overrides.css
+++ b/src/styles/overrides.css
@@ -1,0 +1,37 @@
+/* Styles for removed environment variables */
+.removed-env-vars {
+  margin-top: 16px;
+  padding: 12px;
+  background-color: #f8f8f8;
+  border: 1px solid #edebe9;
+  border-radius: 4px;
+}
+
+.removed-env-vars h4 {
+  margin-top: 0;
+  margin-bottom: 10px;
+  font-size: 0.9rem;
+  color: #605e5c;
+}
+
+.removed-env-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.removed-env-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  background-color: #fde7e9;
+  border: 1px solid #f9c0c5;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+.removed-env-item code {
+  text-decoration: line-through;
+  color: #c50f1f;
+}

--- a/src/styles/validation.css
+++ b/src/styles/validation.css
@@ -1,0 +1,50 @@
+/* Form validation styles */
+.form-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 15px;
+}
+
+.form-validation {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.validation-summary {
+  font-size: 0.85rem;
+  color: #c50f1f;
+}
+
+/* Input validation styles */
+.input-warning {
+  border-color: #ffb900 !important;
+  background-color: #fff4ce !important;
+}
+
+.input-error {
+  border-color: #e74856 !important;
+  background-color: #fde7e9 !important;
+}
+
+.input-message {
+  font-size: 0.8rem;
+  margin-top: 4px;
+  margin-left: 2px;
+}
+
+.input-message.warning {
+  color: #9d5d00;
+}
+
+.input-message.error {
+  color: #c50f1f;
+}
+
+/* Environment variable warnings */
+.env-var-warning {
+  background-color: #fff4ce;
+  border: 1px solid #ffb900;
+  color: #9d5d00;
+}

--- a/src/utils/profileUtils.js
+++ b/src/utils/profileUtils.js
@@ -216,10 +216,38 @@ const calculateOverrides = (masterConfig, targetConfig) => {
 const applyOverrides = (target, overrides) => {
   if (!overrides || typeof overrides !== "object") return;
 
+  // Special handling for environment variables
+  if (overrides.env && typeof overrides.env === "object") {
+    // Handle env vars specially to support "deletion" overrides
+    if (!target.env) {
+      target.env = {};
+    }
+
+    // First, check for special null value which indicates deletion
+    Object.entries(overrides.env).forEach(([key, value]) => {
+      if (value === null) {
+        // If value is explicitly null, remove this env var
+        if (target.env[key] !== undefined) {
+          delete target.env[key];
+        }
+      } else {
+        // Otherwise apply the override normally
+        target.env[key] = value;
+      }
+    });
+    
+    // Skip normal processing for env since we handled it specially
+    const { env, ...otherOverrides } = overrides;
+    applyOverrides(target, otherOverrides);
+    return;
+  }
+
+  // Normal override processing for other properties
   Object.entries(overrides).forEach(([key, value]) => {
     // If the value is an object and the target has the same key with an object value,
     // recursively apply overrides
     if (
+      key !== "env" && // Skip env, we handled it above
       value !== null &&
       typeof value === "object" &&
       !Array.isArray(value) &&

--- a/src/utils/validation/__tests__/mcpValidator.test.js
+++ b/src/utils/validation/__tests__/mcpValidator.test.js
@@ -1,0 +1,542 @@
+/**
+ * Tests for MCP Validator
+ *
+ * These tests verify the validation logic for Model Context Protocol
+ * server configurations.
+ */
+
+import {
+  validateMcpConfig,
+  validateMcpServerConfig,
+  formatSingleServerConfig,
+  formatServerListToMcpJson,
+  applyAutoCorrections,
+  getValidationSummary,
+} from "../mcpValidator";
+
+describe("MCP Validator", () => {
+  describe("validateMcpServerConfig", () => {
+    test("validates a valid server configuration", () => {
+      const serverConfig = {
+        name: "test-server",
+        command: "python",
+        args: ["-m", "mcp_server"],
+        env: {
+          PORT: "8000",
+          NODE_ENV: "development",
+        },
+      };
+
+      const result = validateMcpServerConfig(serverConfig, "test-server");
+      expect(result.errors).toHaveLength(0);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    test("validates a server with missing required properties", () => {
+      const serverConfig = {
+        name: "test-server",
+        command: "python",
+        // Missing args property
+      };
+
+      const result = validateMcpServerConfig(serverConfig, "test-server");
+      expect(result.errors.length).toBeGreaterThan(0);
+      // Check that we get an error about the missing args property
+      expect(result.errors.some((e) => e.path === "args")).toBe(true);
+    });
+
+    test("validates a server with invalid property types", () => {
+      const serverConfig = {
+        name: "test-server",
+        command: 123, // Should be a string
+        args: "not-an-array", // Should be an array
+      };
+
+      const result = validateMcpServerConfig(serverConfig, "test-server");
+      expect(result.errors.length).toBeGreaterThan(0);
+      // Check for errors about invalid types
+      expect(result.errors.some((e) => e.path === "command")).toBe(true);
+      expect(result.errors.some((e) => e.path === "args")).toBe(true);
+    });
+
+    test("validates a server with invalid args items", () => {
+      const serverConfig = {
+        name: "test-server",
+        command: "python",
+        args: ["valid", 123, false], // All items should be strings
+      };
+
+      const result = validateMcpServerConfig(serverConfig, "test-server");
+      expect(result.errors.length).toBeGreaterThan(0);
+      // Check for errors about invalid arg types
+      expect(result.errors.some((e) => e.path === "args[1]")).toBe(true);
+      expect(result.errors.some((e) => e.path === "args[2]")).toBe(true);
+    });
+
+    test("validates a server with invalid env values", () => {
+      const serverConfig = {
+        name: "test-server",
+        command: "python",
+        args: ["-m", "server"],
+        env: {
+          PORT: 8000, // Should be a string
+          DEBUG: true, // Should be a string
+        },
+      };
+
+      const result = validateMcpServerConfig(serverConfig, "test-server");
+      expect(result.errors.length).toBeGreaterThan(0);
+      // Check for errors about invalid env value types
+      expect(result.errors.some((e) => e.path === "env.PORT")).toBe(true);
+      expect(result.errors.some((e) => e.path === "env.DEBUG")).toBe(true);
+    });
+
+    test("warns about potentially unsafe command characters", () => {
+      const serverConfig = {
+        name: "test-server",
+        command: "python -m server; rm -rf /", // Contains shell metacharacters
+        args: [],
+      };
+
+      const result = validateMcpServerConfig(serverConfig, "test-server");
+      expect(result.warnings.length).toBeGreaterThan(0);
+      // Check for warning about unsafe command
+      expect(result.warnings.some((w) => w.path === "command")).toBe(true);
+    });
+
+    test("warns about non-standard env variable names", () => {
+      const serverConfig = {
+        name: "test-server",
+        command: "python",
+        args: ["-m", "server"],
+        env: {
+          "123_invalid": "value", // Should start with letter or underscore
+          "-invalid-var": "value", // Should only contain letters, numbers, underscores
+        },
+      };
+
+      const result = validateMcpServerConfig(serverConfig, "test-server");
+      expect(result.warnings.length).toBeGreaterThan(0);
+      // Check for warnings about env variable names
+      expect(result.warnings.some((w) => w.path === "env.123_invalid")).toBe(
+        true,
+      );
+      expect(result.warnings.some((w) => w.path === "env.-invalid-var")).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("validateMcpConfig", () => {
+    test("validates a valid MCP configuration", () => {
+      const config = {
+        mcpServers: {
+          server1: {
+            command: "python",
+            args: ["-m", "server1"],
+          },
+          server2: {
+            command: "node",
+            args: ["server2.js"],
+          },
+        },
+      };
+
+      const result = validateMcpConfig(config);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    test("validates an invalid MCP configuration", () => {
+      const config = {
+        mcpServers: {
+          server1: {
+            command: "python",
+            // Missing args property
+          },
+          server2: {
+            // Missing command property
+            args: ["server2.js"],
+          },
+        },
+      };
+
+      const result = validateMcpConfig(config);
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+      // Check for errors about the missing properties
+      expect(result.errors.some((e) => e.path.includes("server1.args"))).toBe(
+        true,
+      );
+      expect(
+        result.errors.some((e) => e.path.includes("server2.command")),
+      ).toBe(true);
+    });
+
+    test("validates a server master list format", () => {
+      const config = {
+        "server1-id": {
+          name: "server1",
+          command: "python",
+          args: ["-m", "server1"],
+        },
+        "server2-id": {
+          name: "server2",
+          command: "node",
+          args: ["server2.js"],
+        },
+      };
+
+      const result = validateMcpConfig(config);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    test("handles null or non-object config", () => {
+      const nullResult = validateMcpConfig(null);
+      expect(nullResult.valid).toBe(false);
+      expect(nullResult.errors.length).toBeGreaterThan(0);
+
+      const stringResult = validateMcpConfig("not an object");
+      expect(stringResult.valid).toBe(false);
+      expect(stringResult.errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("formatSingleServerConfig", () => {
+    test("formats a server config with all properties", () => {
+      const serverConfig = {
+        name: "test-server",
+        command: "python",
+        args: ["-m", "server"],
+        env: {
+          PORT: "8000",
+          DEBUG: "true",
+        },
+        resources: [
+          {
+            name: "getDocument",
+            description: "Retrieves a document",
+            parameters: { type: "object" },
+          },
+        ],
+        transport: {
+          type: "http",
+          port: 8000,
+        },
+        // Internal properties that should be excluded
+        id: "123",
+        originalId: "test-server",
+      };
+
+      const formatted = formatSingleServerConfig(serverConfig);
+
+      // Required properties should be included
+      expect(formatted.command).toBe("python");
+      expect(formatted.args).toEqual(["-m", "server"]);
+
+      // Optional properties should be included if present
+      expect(formatted.env).toEqual({ PORT: "8000", DEBUG: "true" });
+      expect(formatted.resources).toHaveLength(1);
+      expect(formatted.transport).toBeDefined();
+
+      // Internal properties should be excluded
+      expect(formatted.id).toBeUndefined();
+      expect(formatted.originalId).toBeUndefined();
+      expect(formatted.name).toBeUndefined();
+    });
+
+    test("formats a minimal server config", () => {
+      const serverConfig = {
+        command: "python",
+        args: ["-m", "server"],
+      };
+
+      const formatted = formatSingleServerConfig(serverConfig);
+
+      // Required properties should be included
+      expect(formatted.command).toBe("python");
+      expect(formatted.args).toEqual(["-m", "server"]);
+
+      // Optional properties should be excluded
+      expect(formatted.env).toBeUndefined();
+      expect(formatted.resources).toBeUndefined();
+      expect(formatted.transport).toBeUndefined();
+    });
+
+    test("handles null or undefined config", () => {
+      const nullResult = formatSingleServerConfig(null);
+      expect(nullResult).toBeNull();
+
+      const undefinedResult = formatSingleServerConfig(undefined);
+      expect(undefinedResult).toBeNull();
+    });
+  });
+
+  describe("formatServerListToMcpJson", () => {
+    test("formats a server list to MCP JSON format", () => {
+      const serverList = {
+        "server1-id": {
+          name: "server1",
+          command: "python",
+          args: ["-m", "server1"],
+          env: { PORT: "8001" },
+        },
+        "server2-id": {
+          name: "server2",
+          command: "node",
+          args: ["server2.js"],
+          env: { PORT: "8002" },
+        },
+      };
+
+      const formatted = formatServerListToMcpJson(serverList);
+
+      // Should have mcpServers property
+      expect(formatted.mcpServers).toBeDefined();
+
+      // Should use names as keys
+      expect(formatted.mcpServers.server1).toBeDefined();
+      expect(formatted.mcpServers.server2).toBeDefined();
+
+      // Should format each server correctly
+      expect(formatted.mcpServers.server1.command).toBe("python");
+      expect(formatted.mcpServers.server1.args).toEqual(["-m", "server1"]);
+      expect(formatted.mcpServers.server1.env).toEqual({ PORT: "8001" });
+
+      expect(formatted.mcpServers.server2.command).toBe("node");
+      expect(formatted.mcpServers.server2.args).toEqual(["server2.js"]);
+      expect(formatted.mcpServers.server2.env).toEqual({ PORT: "8002" });
+    });
+
+    test("handles empty server list", () => {
+      const formatted = formatServerListToMcpJson({});
+      expect(formatted.mcpServers).toEqual({});
+    });
+
+    test("handles null or undefined server list", () => {
+      const nullResult = formatServerListToMcpJson(null);
+      expect(nullResult.mcpServers).toEqual({});
+
+      const undefinedResult = formatServerListToMcpJson(undefined);
+      expect(undefinedResult.mcpServers).toEqual({});
+    });
+
+    test("uses fallback IDs if name is missing", () => {
+      const serverList = {
+        "server1-id": {
+          // No name property
+          command: "python",
+          args: ["-m", "server1"],
+        },
+        "server2-id": {
+          // No name property
+          originalId: "original-server2",
+          command: "node",
+          args: ["server2.js"],
+        },
+      };
+
+      const formatted = formatServerListToMcpJson(serverList);
+
+      // Should use originalId or ID as fallback
+      expect(formatted.mcpServers["server1-id"]).toBeDefined();
+      expect(formatted.mcpServers["original-server2"]).toBeDefined();
+    });
+  });
+
+  describe("applyAutoCorrections", () => {
+    test("applies add/replace suggestions", () => {
+      const config = {
+        name: "test-server",
+        command: "python",
+        // Missing args property
+        env: {
+          PORT: 8000, // Should be a string
+        },
+      };
+
+      const issues = [
+        {
+          path: "args",
+          message: "Missing required args property",
+          suggestion: {
+            action: "add",
+            value: ["-m", "server"],
+          },
+        },
+        {
+          path: "env.PORT",
+          message: "env.PORT must be a string",
+          suggestion: {
+            action: "replace",
+            value: "8000",
+          },
+        },
+      ];
+
+      const corrected = applyAutoCorrections(config, issues);
+
+      // Should have added args property
+      expect(corrected.args).toEqual(["-m", "server"]);
+
+      // Should have replaced env.PORT with string value
+      expect(corrected.env.PORT).toBe("8000");
+    });
+
+    test("applies remove suggestions", () => {
+      const config = {
+        name: "test-server",
+        command: "python",
+        args: ["-m", "server"],
+        invalidProp: "should be removed",
+      };
+
+      const issues = [
+        {
+          path: "invalidProp",
+          message: "Unknown property: invalidProp",
+          suggestion: {
+            action: "remove",
+          },
+        },
+      ];
+
+      const corrected = applyAutoCorrections(config, issues);
+
+      // Should have removed the invalid property
+      expect(corrected.invalidProp).toBeUndefined();
+    });
+
+    test("applies convert suggestions", () => {
+      const config = {
+        name: "test-server",
+        command: "python",
+        args: ["-m", "server", 123, true], // 123 and true should be converted to strings
+      };
+
+      const issues = [
+        {
+          path: "args[1]",
+          message: "Args must be strings",
+          suggestion: {
+            action: "convert",
+          },
+        },
+        {
+          path: "args[2]",
+          message: "Args must be strings",
+          suggestion: {
+            action: "convert",
+          },
+        },
+      ];
+
+      const corrected = applyAutoCorrections(config, issues);
+
+      // Should have converted non-string args to strings
+      expect(corrected.args[1]).toBe("123");
+      expect(corrected.args[2]).toBe("true");
+    });
+
+    test("handles deep paths", () => {
+      const config = {
+        resources: [
+          {
+            name: "resource1",
+            description: "A resource",
+            parameters: {
+              type: "string", // Should be 'object'
+            },
+          },
+        ],
+      };
+
+      const issues = [
+        {
+          path: "resources[0].parameters.type",
+          message: 'Parameters type must be "object"',
+          suggestion: {
+            action: "replace",
+            value: "object",
+          },
+        },
+      ];
+
+      const corrected = applyAutoCorrections(config, issues);
+
+      // Should have corrected the deep property
+      expect(corrected.resources[0].parameters.type).toBe("object");
+    });
+
+    test("ignores issues without suggestions", () => {
+      const config = {
+        name: "test-server",
+        command: "python",
+        args: ["-m", "server"],
+      };
+
+      const issues = [
+        {
+          path: "name",
+          message: "Invalid name format",
+          // No suggestion
+        },
+      ];
+
+      const corrected = applyAutoCorrections(config, issues);
+
+      // Config should remain unchanged
+      expect(corrected).toEqual(config);
+    });
+  });
+
+  describe("getValidationSummary", () => {
+    test("summarizes a valid configuration", () => {
+      const result = {
+        valid: true,
+        errors: [],
+        warnings: [],
+      };
+
+      const summary = getValidationSummary(result);
+      expect(summary).toBe("Configuration is valid");
+    });
+
+    test("summarizes a valid configuration with warnings", () => {
+      const result = {
+        valid: true,
+        errors: [],
+        warnings: [
+          { path: "command", message: "Unsafe command" },
+          { path: "env.VAR", message: "Invalid variable name" },
+        ],
+      };
+
+      const summary = getValidationSummary(result);
+      expect(summary).toBe("Configuration is valid with 2 warning(s)");
+    });
+
+    test("summarizes an invalid configuration", () => {
+      const result = {
+        valid: false,
+        errors: [
+          { path: "command", message: "Missing command" },
+          { path: "args", message: "Invalid args" },
+        ],
+        warnings: [{ path: "env.VAR", message: "Invalid variable name" }],
+      };
+
+      const summary = getValidationSummary(result);
+      expect(summary).toBe("Configuration has 2 error(s) and 1 warning(s)");
+    });
+
+    test("handles null or undefined result", () => {
+      const nullSummary = getValidationSummary(null);
+      expect(nullSummary).toBe("Configuration not validated");
+
+      const undefinedSummary = getValidationSummary(undefined);
+      expect(undefinedSummary).toBe("Configuration not validated");
+    });
+  });
+});

--- a/src/utils/validation/mcpSchema.js
+++ b/src/utils/validation/mcpSchema.js
@@ -1,0 +1,85 @@
+/**
+ * MCP Schema Definitions
+ * Based on Model Context Protocol specification
+ */
+
+// Base MCP configuration schema
+export const mcpConfigSchema = {
+  type: "object",
+  required: ["mcpServers"],
+  properties: {
+    mcpServers: {
+      type: "object",
+      additionalProperties: {
+        $ref: "#/definitions/serverConfig",
+      },
+    },
+  },
+  definitions: {
+    serverConfig: {
+      type: "object",
+      required: ["command", "args"],
+      properties: {
+        command: { type: "string" },
+        args: {
+          type: "array",
+          items: { type: "string" },
+        },
+        env: {
+          type: "object",
+          additionalProperties: { type: "string" },
+        },
+        resources: {
+          type: "array",
+          items: { $ref: "#/definitions/resource" },
+        },
+      },
+    },
+    resource: {
+      type: "object",
+      required: ["name", "description", "parameters"],
+      properties: {
+        name: { type: "string" },
+        description: { type: "string" },
+        parameters: { type: "object" },
+      },
+    },
+  },
+};
+
+// Transport-specific schemas
+export const transportSchemas = {
+  http: {
+    type: "object",
+    properties: {
+      port: { type: "number" },
+      host: { type: "string", default: "localhost" },
+      ssl: { type: "boolean", default: false },
+    },
+  },
+  websocket: {
+    type: "object",
+    properties: {
+      port: { type: "number" },
+      host: { type: "string", default: "localhost" },
+      path: { type: "string", default: "/mcp" },
+      ssl: { type: "boolean", default: false },
+    },
+  },
+  stdio: {
+    type: "object",
+    properties: {
+      bufferSize: { type: "number", default: 4096 },
+    },
+  },
+};
+
+// Common patterns for validation
+export const validationPatterns = {
+  // Environment variable name pattern
+  envVarName: /^[a-zA-Z_][a-zA-Z0-9_]*$/,
+  // Command pattern (no shell metacharacters)
+  safeCommand: /^[^;&|<>$\\]*$/,
+  // Resource name pattern (camelCase)
+  resourceName: /^[a-z][a-zA-Z0-9]*$/,
+};

--- a/src/utils/validation/mcpValidator.js
+++ b/src/utils/validation/mcpValidator.js
@@ -1,0 +1,162 @@
+/**
+ * MCP Schema Validator
+ * Validates JSON configurations against the Model Context Protocol specification
+ */
+
+/**
+ * Validates a complete MCP configuration object
+ * @param {Object} config - The MCP configuration to validate
+ * @returns {Object} Validation result: { valid: boolean, errors: Array }
+ */
+export const validateMcpConfig = (config) => {
+  const errors = [];
+
+  // Check if config is an object
+  if (!config || typeof config !== "object") {
+    return {
+      valid: false,
+      errors: ["Invalid configuration: Must be a JSON object"],
+    };
+  }
+
+  // Check for mcpServers property (required for profiles)
+  if (config.mcpServers !== undefined) {
+    if (typeof config.mcpServers !== "object") {
+      errors.push("mcpServers property must be an object");
+    } else {
+      // Validate each server in mcpServers
+      Object.entries(config.mcpServers).forEach(
+        ([serverName, serverConfig]) => {
+          const serverErrors = validateMcpServerConfig(
+            serverConfig,
+            serverName,
+          );
+          errors.push(...serverErrors);
+        },
+      );
+    }
+  }
+  // For server master list, validate each individual server
+  else {
+    Object.entries(config).forEach(([serverId, serverConfig]) => {
+      const serverErrors = validateMcpServerConfig(
+        serverConfig,
+        serverConfig.name || serverId,
+      );
+      errors.push(...serverErrors);
+    });
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+};
+
+/**
+ * Validates a single MCP server configuration
+ * @param {Object} serverConfig - The server configuration to validate
+ * @param {string} serverName - The name of the server (for error messages)
+ * @returns {Array} List of validation errors
+ */
+export const validateMcpServerConfig = (serverConfig, serverName) => {
+  const errors = [];
+
+  // Server must be an object
+  if (!serverConfig || typeof serverConfig !== "object") {
+    return [`Server '${serverName}': Configuration must be an object`];
+  }
+
+  // Required properties
+  if (!serverConfig.command) {
+    errors.push(`Server '${serverName}': Missing required 'command' property`);
+  } else if (typeof serverConfig.command !== "string") {
+    errors.push(`Server '${serverName}': 'command' must be a string`);
+  }
+
+  // args property (required)
+  if (!Array.isArray(serverConfig.args)) {
+    errors.push(`Server '${serverName}': 'args' must be an array`);
+  } else {
+    // Validate each arg is a string
+    serverConfig.args.forEach((arg, index) => {
+      if (typeof arg !== "string") {
+        errors.push(`Server '${serverName}': args[${index}] must be a string`);
+      }
+    });
+  }
+
+  // env property (optional)
+  if (serverConfig.env !== undefined) {
+    if (
+      typeof serverConfig.env !== "object" ||
+      Array.isArray(serverConfig.env)
+    ) {
+      errors.push(`Server '${serverName}': 'env' must be an object`);
+    } else {
+      // Validate each env var is a string
+      Object.entries(serverConfig.env).forEach(([key, value]) => {
+        if (typeof value !== "string") {
+          errors.push(`Server '${serverName}': env.${key} must be a string`);
+        }
+      });
+    }
+  }
+
+  // originalId property (optional for internal use)
+  if (
+    serverConfig.originalId !== undefined &&
+    typeof serverConfig.originalId !== "string"
+  ) {
+    errors.push(`Server '${serverName}': 'originalId' must be a string`);
+  }
+
+  // name property (optional for internal use)
+  if (
+    serverConfig.name !== undefined &&
+    typeof serverConfig.name !== "string"
+  ) {
+    errors.push(`Server '${serverName}': 'name' must be a string`);
+  }
+
+  return errors;
+};
+
+/**
+ * Formats server configuration in MCP standard format
+ * @param {Object} serverConfig - The server configuration object
+ * @returns {Object} Properly formatted single server object
+ */
+export const formatSingleServerConfig = (serverConfig) => {
+  // Create expected MCP server object format
+  return {
+    command: serverConfig.command || "",
+    args: Array.isArray(serverConfig.args) ? [...serverConfig.args] : [],
+    ...(serverConfig.env && Object.keys(serverConfig.env).length > 0
+      ? { env: { ...serverConfig.env } }
+      : {}),
+  };
+};
+
+/**
+ * Formats a server list into MCP server object
+ * @param {Object} serverList - The server list from master list
+ * @returns {Object} Properly formatted mcpServers object
+ */
+export const formatServerListToMcpJson = (serverList) => {
+  if (!serverList || typeof serverList !== "object") {
+    return { mcpServers: {} };
+  }
+
+  const mcpServers = {};
+
+  Object.entries(serverList).forEach(([serverId, server]) => {
+    // Use name as key, fallback to originalId or serverId
+    const serverName = server.name || server.originalId || serverId;
+
+    // Format in MCP standard format
+    mcpServers[serverName] = formatSingleServerConfig(server);
+  });
+
+  return { mcpServers };
+};

--- a/src/utils/validation/mcpValidator.js
+++ b/src/utils/validation/mcpValidator.js
@@ -3,112 +3,455 @@
  * Validates JSON configurations against the Model Context Protocol specification
  */
 
+import {
+  mcpConfigSchema,
+  transportSchemas,
+  validationPatterns,
+} from "./mcpSchema";
+
 /**
  * Validates a complete MCP configuration object
  * @param {Object} config - The MCP configuration to validate
- * @returns {Object} Validation result: { valid: boolean, errors: Array }
+ * @returns {Object} Validation result: { valid: boolean, errors: Array, warnings: Array }
  */
 export const validateMcpConfig = (config) => {
-  const errors = [];
+  const result = {
+    valid: false,
+    errors: [],
+    warnings: [],
+  };
 
   // Check if config is an object
   if (!config || typeof config !== "object") {
-    return {
-      valid: false,
-      errors: ["Invalid configuration: Must be a JSON object"],
-    };
+    result.errors.push({
+      path: "",
+      message: "Invalid configuration: Must be a JSON object",
+    });
+    return result;
   }
 
-  // Check for mcpServers property (required for profiles)
-  if (config.mcpServers !== undefined) {
-    if (typeof config.mcpServers !== "object") {
-      errors.push("mcpServers property must be an object");
+  // For profiles format (mcpServers property)
+  if ("mcpServers" in config) {
+    if (
+      typeof config.mcpServers !== "object" ||
+      Array.isArray(config.mcpServers)
+    ) {
+      result.errors.push({
+        path: "mcpServers",
+        message: "mcpServers property must be an object",
+        suggestion: {
+          action: "replace",
+          value: {},
+          description: "Replace with an empty object",
+        },
+      });
     } else {
       // Validate each server in mcpServers
       Object.entries(config.mcpServers).forEach(
         ([serverName, serverConfig]) => {
-          const serverErrors = validateMcpServerConfig(
+          const serverValidation = validateMcpServerConfig(
             serverConfig,
             serverName,
           );
-          errors.push(...serverErrors);
+
+          // Add server errors with prefixed path
+          serverValidation.errors.forEach((error) => {
+            result.errors.push({
+              path: `mcpServers.${serverName}${error.path ? "." + error.path : ""}`,
+              message: error.message,
+              suggestion: error.suggestion,
+            });
+          });
+
+          // Add server warnings with prefixed path
+          serverValidation.warnings.forEach((warning) => {
+            result.warnings.push({
+              path: `mcpServers.${serverName}${warning.path ? "." + warning.path : ""}`,
+              message: warning.message,
+              suggestion: warning.suggestion,
+            });
+          });
         },
       );
     }
   }
-  // For server master list, validate each individual server
+  // For server master list format
   else {
     Object.entries(config).forEach(([serverId, serverConfig]) => {
-      const serverErrors = validateMcpServerConfig(
+      const serverValidation = validateMcpServerConfig(
         serverConfig,
         serverConfig.name || serverId,
       );
-      errors.push(...serverErrors);
+
+      // Add server errors with prefixed path
+      serverValidation.errors.forEach((error) => {
+        result.errors.push({
+          path: `${serverId}${error.path ? "." + error.path : ""}`,
+          message: error.message,
+          suggestion: error.suggestion,
+        });
+      });
+
+      // Add server warnings with prefixed path
+      serverValidation.warnings.forEach((warning) => {
+        result.warnings.push({
+          path: `${serverId}${warning.path ? "." + warning.path : ""}`,
+          message: warning.message,
+          suggestion: warning.suggestion,
+        });
+      });
     });
   }
 
-  return {
-    valid: errors.length === 0,
-    errors,
-  };
+  // Set valid flag based on errors count
+  result.valid = result.errors.length === 0;
+
+  return result;
 };
 
 /**
  * Validates a single MCP server configuration
  * @param {Object} serverConfig - The server configuration to validate
  * @param {string} serverName - The name of the server (for error messages)
- * @returns {Array} List of validation errors
+ * @returns {Object} { errors: Array, warnings: Array }
  */
 export const validateMcpServerConfig = (serverConfig, serverName) => {
-  const errors = [];
+  const result = {
+    errors: [],
+    warnings: [],
+  };
 
   // Server must be an object
   if (!serverConfig || typeof serverConfig !== "object") {
-    return [`Server '${serverName}': Configuration must be an object`];
+    result.errors.push({
+      path: "",
+      message: `Server '${serverName}': Configuration must be an object`,
+    });
+    return result;
   }
 
-  // Required properties
+  // Validate command property (required)
   if (!serverConfig.command) {
-    errors.push(`Server '${serverName}': Missing required 'command' property`);
+    result.errors.push({
+      path: "command",
+      message: `Missing required 'command' property`,
+      suggestion: {
+        action: "add",
+        value: "python -m my_mcp_server",
+        description: "Add a command to run the server",
+      },
+    });
   } else if (typeof serverConfig.command !== "string") {
-    errors.push(`Server '${serverName}': 'command' must be a string`);
+    result.errors.push({
+      path: "command",
+      message: `'command' must be a string`,
+      suggestion: {
+        action: "convert",
+        description: "Convert command to string",
+      },
+    });
+  } else if (!validationPatterns.safeCommand.test(serverConfig.command)) {
+    result.warnings.push({
+      path: "command",
+      message: `Command contains potentially unsafe characters`,
+      suggestion: {
+        action: "review",
+        description: "Review for shell metacharacters (;&|<>$\\)",
+      },
+    });
   }
 
-  // args property (required)
+  // Validate args property (required)
   if (!Array.isArray(serverConfig.args)) {
-    errors.push(`Server '${serverName}': 'args' must be an array`);
+    result.errors.push({
+      path: "args",
+      message: `'args' must be an array`,
+      suggestion: {
+        action: "replace",
+        value: [],
+        description: "Replace with an empty array",
+      },
+    });
   } else {
     // Validate each arg is a string
     serverConfig.args.forEach((arg, index) => {
       if (typeof arg !== "string") {
-        errors.push(`Server '${serverName}': args[${index}] must be a string`);
+        result.errors.push({
+          path: `args[${index}]`,
+          message: `args[${index}] must be a string`,
+          suggestion: {
+            action: "convert",
+            description: "Convert argument to string",
+          },
+        });
       }
     });
   }
 
-  // env property (optional)
+  // Validate env property (optional)
   if (serverConfig.env !== undefined) {
     if (
       typeof serverConfig.env !== "object" ||
       Array.isArray(serverConfig.env)
     ) {
-      errors.push(`Server '${serverName}': 'env' must be an object`);
+      result.errors.push({
+        path: "env",
+        message: `'env' must be an object`,
+        suggestion: {
+          action: "replace",
+          value: {},
+          description: "Replace with an empty object",
+        },
+      });
     } else {
-      // Validate each env var is a string
+      // Validate each env var is a string and follows naming patterns
       Object.entries(serverConfig.env).forEach(([key, value]) => {
         if (typeof value !== "string") {
-          errors.push(`Server '${serverName}': env.${key} must be a string`);
+          result.errors.push({
+            path: `env.${key}`,
+            message: `env.${key} must be a string`,
+            suggestion: {
+              action: "convert",
+              description: "Convert value to string",
+            },
+          });
+        }
+
+        // Check environment variable name pattern
+        if (!validationPatterns.envVarName.test(key)) {
+          result.warnings.push({
+            path: `env.${key}`,
+            message: `Environment variable name '${key}' does not follow standard pattern`,
+            suggestion: {
+              action: "rename",
+              description:
+                "Rename to follow pattern: letters, numbers, underscores (starting with letter/underscore)",
+            },
+          });
         }
       });
     }
   }
 
+  // Validate resources property (optional)
+  if (serverConfig.resources !== undefined) {
+    validateResourceDefinitions(serverConfig.resources, result);
+  }
+
+  // Validate transport property (optional)
+  if (serverConfig.transport !== undefined) {
+    validateTransportConfig(serverConfig.transport, result);
+  }
+
+  // Validate internal properties (not in MCP spec but used by the application)
+  validateInternalProperties(serverConfig, result);
+
+  return result;
+};
+
+/**
+ * Validates resource definitions
+ * @param {Array} resources - Array of resource definition objects
+ * @param {Object} result - Validation result to append to
+ */
+const validateResourceDefinitions = (resources, result) => {
+  if (!Array.isArray(resources)) {
+    result.errors.push({
+      path: "resources",
+      message: "Resources must be an array",
+      suggestion: {
+        action: "replace",
+        value: [],
+        description: "Replace with an empty array",
+      },
+    });
+    return;
+  }
+
+  resources.forEach((resource, index) => {
+    const basePath = `resources[${index}]`;
+
+    // Check for required properties
+    if (!resource.name) {
+      result.errors.push({
+        path: `${basePath}.name`,
+        message: "Missing required resource name",
+        suggestion: {
+          action: "add",
+          description: "Add a name property",
+        },
+      });
+    } else if (typeof resource.name !== "string") {
+      result.errors.push({
+        path: `${basePath}.name`,
+        message: "Resource name must be a string",
+        suggestion: {
+          action: "convert",
+          description: "Convert to string",
+        },
+      });
+    } else if (!validationPatterns.resourceName.test(resource.name)) {
+      result.warnings.push({
+        path: `${basePath}.name`,
+        message: `Resource name '${resource.name}' should follow camelCase pattern`,
+        suggestion: {
+          action: "rename",
+          description: "Rename to follow camelCase pattern",
+        },
+      });
+    }
+
+    if (!resource.description) {
+      result.errors.push({
+        path: `${basePath}.description`,
+        message: "Missing required resource description",
+        suggestion: {
+          action: "add",
+          description: "Add a description property",
+        },
+      });
+    } else if (typeof resource.description !== "string") {
+      result.errors.push({
+        path: `${basePath}.description`,
+        message: "Resource description must be a string",
+        suggestion: {
+          action: "convert",
+          description: "Convert to string",
+        },
+      });
+    }
+
+    if (!resource.parameters) {
+      result.errors.push({
+        path: `${basePath}.parameters`,
+        message: "Missing required parameters definition",
+        suggestion: {
+          action: "add",
+          value: { type: "object", properties: {} },
+          description: "Add a parameters object",
+        },
+      });
+    } else if (typeof resource.parameters !== "object") {
+      result.errors.push({
+        path: `${basePath}.parameters`,
+        message: "Parameters must be an object",
+        suggestion: {
+          action: "replace",
+          value: { type: "object", properties: {} },
+          description: "Replace with a valid parameters object",
+        },
+      });
+    }
+  });
+};
+
+/**
+ * Validates transport configuration
+ * @param {Object} transport - Transport configuration
+ * @param {Object} result - Validation result to append to
+ */
+const validateTransportConfig = (transport, result) => {
+  if (typeof transport !== "object" || Array.isArray(transport)) {
+    result.errors.push({
+      path: "transport",
+      message: "Transport must be an object",
+      suggestion: {
+        action: "replace",
+        value: { type: "http" },
+        description: "Replace with a basic HTTP transport configuration",
+      },
+    });
+    return;
+  }
+
+  // Check for required transport type
+  if (!transport.type) {
+    result.errors.push({
+      path: "transport.type",
+      message: "Missing required transport type",
+      suggestion: {
+        action: "add",
+        value: "http",
+        description: "Add a transport type",
+      },
+    });
+    return;
+  }
+
+  // Validate based on transport type
+  const supportedTypes = Object.keys(transportSchemas);
+  if (!supportedTypes.includes(transport.type)) {
+    result.errors.push({
+      path: "transport.type",
+      message: `Unsupported transport type: ${transport.type}`,
+      suggestion: {
+        action: "replace",
+        value: "http",
+        description: `Supported types: ${supportedTypes.join(", ")}`,
+      },
+    });
+    return;
+  }
+
+  // Get the schema for this transport type
+  const schema = transportSchemas[transport.type];
+
+  // Validate properties against schema
+  Object.entries(transport).forEach(([key, value]) => {
+    if (key === "type") return; // Already validated
+
+    const propertySchema = schema.properties[key];
+
+    // Check if property is defined in schema
+    if (!propertySchema) {
+      result.warnings.push({
+        path: `transport.${key}`,
+        message: `Unknown property for ${transport.type} transport: ${key}`,
+        suggestion: {
+          action: "remove",
+          description: `This property is not defined in the ${transport.type} transport schema`,
+        },
+      });
+      return;
+    }
+
+    // Validate property type
+    const expectedType = propertySchema.type;
+    const actualType = Array.isArray(value) ? "array" : typeof value;
+
+    if (actualType !== expectedType) {
+      result.errors.push({
+        path: `transport.${key}`,
+        message: `Property ${key} must be type: ${expectedType}, found: ${actualType}`,
+        suggestion: {
+          action: "replace",
+          value: propertySchema.default,
+          description: `Replace with a value of type: ${expectedType}`,
+        },
+      });
+    }
+  });
+};
+
+/**
+ * Validates internal properties used by the application
+ * @param {Object} serverConfig - Server configuration
+ * @param {Object} result - Validation result to append to
+ */
+const validateInternalProperties = (serverConfig, result) => {
   // originalId property (optional for internal use)
   if (
     serverConfig.originalId !== undefined &&
     typeof serverConfig.originalId !== "string"
   ) {
-    errors.push(`Server '${serverName}': 'originalId' must be a string`);
+    result.errors.push({
+      path: "originalId",
+      message: "originalId must be a string",
+      suggestion: {
+        action: "convert",
+        description: "Convert to string",
+      },
+    });
   }
 
   // name property (optional for internal use)
@@ -116,32 +459,88 @@ export const validateMcpServerConfig = (serverConfig, serverName) => {
     serverConfig.name !== undefined &&
     typeof serverConfig.name !== "string"
   ) {
-    errors.push(`Server '${serverName}': 'name' must be a string`);
+    result.errors.push({
+      path: "name",
+      message: "name must be a string",
+      suggestion: {
+        action: "convert",
+        description: "Convert to string",
+      },
+    });
   }
 
-  return errors;
+  // enabled property (optional for profile servers)
+  if (
+    serverConfig.enabled !== undefined &&
+    typeof serverConfig.enabled !== "boolean"
+  ) {
+    result.errors.push({
+      path: "enabled",
+      message: "enabled must be a boolean",
+      suggestion: {
+        action: "convert",
+        value: Boolean(serverConfig.enabled),
+        description: "Convert to boolean",
+      },
+    });
+  }
+
+  // overrides property (optional for profile servers)
+  if (
+    serverConfig.overrides !== undefined &&
+    (typeof serverConfig.overrides !== "object" ||
+      Array.isArray(serverConfig.overrides))
+  ) {
+    result.errors.push({
+      path: "overrides",
+      message: "overrides must be an object",
+      suggestion: {
+        action: "replace",
+        value: {},
+        description: "Replace with an empty object",
+      },
+    });
+  }
 };
 
 /**
- * Formats server configuration in MCP standard format
- * @param {Object} serverConfig - The server configuration object
- * @returns {Object} Properly formatted single server object
+ * Formats a single server configuration to MCP standard
+ * @param {Object} serverConfig - Server configuration object
+ * @returns {Object} MCP-compliant server configuration
  */
 export const formatSingleServerConfig = (serverConfig) => {
-  // Create expected MCP server object format
-  return {
+  if (!serverConfig) return null;
+
+  // Create base configuration with required properties
+  const formatted = {
     command: serverConfig.command || "",
     args: Array.isArray(serverConfig.args) ? [...serverConfig.args] : [],
-    ...(serverConfig.env && Object.keys(serverConfig.env).length > 0
-      ? { env: { ...serverConfig.env } }
-      : {}),
   };
+
+  // Add optional properties if they exist
+  if (serverConfig.env && Object.keys(serverConfig.env).length > 0) {
+    formatted.env = { ...serverConfig.env };
+  }
+
+  if (
+    serverConfig.resources &&
+    Array.isArray(serverConfig.resources) &&
+    serverConfig.resources.length > 0
+  ) {
+    formatted.resources = [...serverConfig.resources];
+  }
+
+  if (serverConfig.transport && typeof serverConfig.transport === "object") {
+    formatted.transport = { ...serverConfig.transport };
+  }
+
+  return formatted;
 };
 
 /**
- * Formats a server list into MCP server object
- * @param {Object} serverList - The server list from master list
- * @returns {Object} Properly formatted mcpServers object
+ * Formats server list into MCP-compliant JSON
+ * @param {Object} serverList - Server list object
+ * @returns {Object} MCP-compliant configuration
  */
 export const formatServerListToMcpJson = (serverList) => {
   if (!serverList || typeof serverList !== "object") {
@@ -159,4 +558,139 @@ export const formatServerListToMcpJson = (serverList) => {
   });
 
   return { mcpServers };
+};
+
+/**
+ * Applies auto-correction to fix common validation issues
+ * @param {Object} config - Original configuration
+ * @param {Array} issues - Validation errors/warnings with suggestions
+ * @returns {Object} Corrected configuration
+ */
+export const applyAutoCorrections = (config, issues) => {
+  // Create a deep copy of the configuration
+  const corrected = JSON.parse(JSON.stringify(config));
+
+  // Apply corrections for each issue that has a suggestion
+  issues.forEach((issue) => {
+    if (!issue.suggestion) return;
+
+    // Parse the path to navigate the object
+    const pathParts = issue.path.split(".");
+
+    // Navigate to the parent object
+    let current = corrected;
+    let parent = null;
+    let lastKey = null;
+
+    for (let i = 0; i < pathParts.length - 1; i++) {
+      const part = pathParts[i];
+
+      // Handle array indices
+      if (part.includes("[") && part.includes("]")) {
+        const arrName = part.substring(0, part.indexOf("["));
+        const index = parseInt(
+          part.substring(part.indexOf("[") + 1, part.indexOf("]")),
+        );
+
+        if (!current[arrName]) current[arrName] = [];
+        parent = current;
+        current = current[arrName];
+        lastKey = index;
+      } else {
+        if (!current[part]) current[part] = {};
+        parent = current;
+        current = current[part];
+        lastKey = part;
+      }
+    }
+
+    // Get the final property name
+    const finalProp = pathParts[pathParts.length - 1];
+
+    // Apply the correction based on the suggestion type
+    switch (issue.suggestion.action) {
+      case "add":
+      case "replace":
+        if (finalProp.includes("[") && finalProp.includes("]")) {
+          const arrName = finalProp.substring(0, finalProp.indexOf("["));
+          const index = parseInt(
+            finalProp.substring(
+              finalProp.indexOf("[") + 1,
+              finalProp.indexOf("]"),
+            ),
+          );
+
+          if (!current[arrName]) current[arrName] = [];
+          if (typeof issue.suggestion.value !== "undefined") {
+            current[arrName][index] = issue.suggestion.value;
+          }
+        } else {
+          if (typeof issue.suggestion.value !== "undefined") {
+            current[finalProp] = issue.suggestion.value;
+          }
+        }
+        break;
+
+      case "remove":
+        if (finalProp.includes("[") && finalProp.includes("]")) {
+          const arrName = finalProp.substring(0, finalProp.indexOf("["));
+          const index = parseInt(
+            finalProp.substring(
+              finalProp.indexOf("[") + 1,
+              finalProp.indexOf("]"),
+            ),
+          );
+
+          if (current[arrName] && Array.isArray(current[arrName])) {
+            current[arrName].splice(index, 1);
+          }
+        } else {
+          delete current[finalProp];
+        }
+        break;
+
+      case "convert":
+        if (finalProp.includes("[") && finalProp.includes("]")) {
+          const arrName = finalProp.substring(0, finalProp.indexOf("["));
+          const index = parseInt(
+            finalProp.substring(
+              finalProp.indexOf("[") + 1,
+              finalProp.indexOf("]"),
+            ),
+          );
+
+          if (current[arrName] && Array.isArray(current[arrName])) {
+            // Convert to string
+            current[arrName][index] = String(current[arrName][index]);
+          }
+        } else if (current[finalProp] !== undefined) {
+          // Convert to string
+          current[finalProp] = String(current[finalProp]);
+        }
+        break;
+    }
+  });
+
+  return corrected;
+};
+
+/**
+ * Get a human-readable validation summary
+ * @param {Object} validationResult - Validation result from validateMcpConfig
+ * @returns {string} A summary of validation issues
+ */
+export const getValidationSummary = (validationResult) => {
+  if (!validationResult) {
+    return "Configuration not validated";
+  }
+
+  if (validationResult.valid && validationResult.warnings.length === 0) {
+    return "Configuration is valid";
+  }
+
+  if (validationResult.valid && validationResult.warnings.length > 0) {
+    return `Configuration is valid with ${validationResult.warnings.length} warning(s)`;
+  }
+
+  return `Configuration has ${validationResult.errors.length} error(s) and ${validationResult.warnings.length} warning(s)`;
 };


### PR DESCRIPTION
### Add Comprehensive Testing Support

- Introduced full Jest testing support for MCP Palette:
  - Added jest.config.js for configuration.
  - Added mocks for files and styles to support React Testing Library and Jest.
  - Integrated @testing-library/react, @testing-library/jest-dom, and related dependencies.
  - Updated README.md with clear testing instructions, including coverage and suite-specific commands.
- Added Babel configuration (.babelrc) to support modern JavaScript and React (automatic runtime).
- Updated package-lock.json to include all new dev dependencies for testing and Babel.
- Project name and version updated to mcp-palette@1.2.0 for this release.

### Why
This PR enables robust, maintainable testing for MCP Palette, making it easier to ensure code quality and reliability as the project grows.