### PR TITLE
Update/docs ci badges

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,29 @@
+# Recommended Codecov configuration for a JS/Electron/React project
+coverage:
+  status:
+    project:
+      default:
+        # Set a minimum project-wide coverage threshold (optional)
+        target: 80%
+        threshold: 1%
+    patch:
+      default:
+        # Set a minimum coverage for changed lines (optional)
+        target: 70%
+        threshold: 1%
+  precision: 2
+  round: down
+  range: "70...100"
+ignore:
+  - "**/__mocks__/**"
+  - "**/*.test.js"
+  - "**/*.test.jsx"
+  - "**/test-utils/**"
+  - "**/scripts/**"
+  - "**/dist/**"
+  - "**/electron/**"
+  - "**/public/**"
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests with coverage
+        run: npm test -- --coverage --coverageReporters=text-lcov
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage/lcov.info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: write
+
 jobs:
   build-and-release:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-and-release:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build app
+        run: npm run electron:build
+      - name: Package app
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            npx electron-builder --linux
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            npx electron-builder --mac
+          elif [ "$RUNNER_OS" == "Windows" ]; then
+            npx electron-builder --win
+          fi
+        shell: bash
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ runner.os }}-artifacts
+          path: dist/
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          files: dist/**/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 cellwebb
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -26,11 +26,15 @@ MCP Palette is a modern, user-friendly desktop application for managing Model Co
 
 ## 🖥️ Installation & Usage
 
+For installation instructions, see the [Installation Guide](docs/INSTALLATION.md).
+
 **For End Users:**
 
 1. Go to the [Releases page](https://github.com/cellwebb/mcp-palette/releases) and download the installer or binary for your operating system (e.g., `.dmg` for Mac, `.exe` for Windows).
 2. Run the installer and follow the prompts to install MCP Palette on your computer.
 3. Launch MCP Palette from your Applications folder (Mac) or Start Menu/Desktop (Windows).
+
+For usage details and feature explanations, see the [Usage Guide](docs/USAGE.md).
 
 **For Developers/Contributors:**
 
@@ -55,6 +59,13 @@ MCP Palette is a modern, user-friendly desktop application for managing Model Co
 
 **Note:**
 - If you need a Windows or Linux installer and are on a Mac, use GitHub Actions or a Windows/Linux machine to build for those platforms. See below for cross-platform automation.
+
+## 📖 Documentation
+
+- [Installation Guide](docs/INSTALLATION.md)
+- [Usage Guide](docs/USAGE.md)
+- [Contributing Guide](docs/CONTRIBUTING.md)
+- [Release Guide](docs/RELEASING.md)
 
 ## 🏗️ Development
 
@@ -113,6 +124,10 @@ npm test:validation # Validation tests
 - All necessary dev dependencies (`jest`, `@testing-library/react`, `babel-jest`, etc.) are included in `package.json`.
 - File and style mocks are provided in `__mocks__/` for robust component testing.
 - Babel is used for modern JS/React syntax support (see `.babelrc`).
+
+For contributing, see the [Contributing Guide](docs/CONTRIBUTING.md).
+
+For release instructions, see the [Release Guide](docs/RELEASING.md).
 
 ## 🛠️ Babel
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,15 @@ For usage details and feature explanations, see the [Usage Guide](docs/USAGE.md)
 
 - [Installation Guide](docs/INSTALLATION.md)
 - [Usage Guide](docs/USAGE.md)
+- [Architecture Overview](docs/ARCHITECTURE.md)
 - [Contributing Guide](docs/CONTRIBUTING.md)
 - [Release Guide](docs/RELEASING.md)
 
 ## 🏗️ Development
 
 This project uses Vite for frontend development and Electron for the desktop application wrapper.
+
+For an overview of the project structure and core concepts, see the [Architecture Overview](docs/ARCHITECTURE.md).
 
 ### Continuous Integration
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # MCP Palette: Model Context Protocol Server Manager
+[![Build Status](https://github.com/cellwebb/mcp-palette/actions/workflows/ci.yml/badge.svg)](https://github.com/cellwebb/mcp-palette/actions/workflows/ci.yml)
+[![Coverage Status](https://codecov.io/gh/cellwebb/mcp-palette/branch/main/graph/badge.svg)](https://codecov.io/gh/cellwebb/mcp-palette)
+[![npm version](https://img.shields.io/npm/v/mcp-palette.svg)](https://www.npmjs.com/package/mcp-palette)
+[![License: MIT](https://img.shields.io/npm/l/mcp-palette.svg)](https://github.com/cellwebb/mcp-palette/blob/main/LICENSE)
 
 MCP Palette is a modern, user-friendly desktop application for managing Model Context Protocol (MCP) server configurations. It provides a centralized interface to configure, manage, and deploy MCP servers for use with Large Language Models (LLMs) and AI assistants.
 
@@ -50,6 +54,10 @@ chmod +x start.sh  # Make the script executable (first time only)
 ## 🏗️ Development
 
 This project uses Vite for frontend development and Electron for the desktop application wrapper.
+
+### Continuous Integration
+
+This project uses GitHub Actions for continuous integration. On each push or pull request to the `main` branch, the CI workflow installs dependencies, runs tests with coverage, and uploads coverage reports to Codecov.
 
 ```bash
 # Start Vite development server
@@ -157,7 +165,9 @@ Contributions are welcome! Feel free to submit issues or pull requests.
 
 ## 📝 License
 
-MIT
+MIT License
+
+See [LICENSE](./LICENSE) for details.
 
 ## 📚 Related Projects
 

--- a/README.md
+++ b/README.md
@@ -24,32 +24,37 @@ MCP Palette is a modern, user-friendly desktop application for managing Model Co
 - Create specialized profiles for different AI assistant use cases
 - Deploy consistent MCP server configurations in production environments
 
-## 💻 Installation
+## 🖥️ Installation & Usage
 
-### Prerequisites
+**For End Users:**
 
-- Node.js 18+ and npm
+1. Go to the [Releases page](https://github.com/cellwebb/mcp-palette/releases) and download the installer or binary for your operating system (e.g., `.dmg` for Mac, `.exe` for Windows).
+2. Run the installer and follow the prompts to install MCP Palette on your computer.
+3. Launch MCP Palette from your Applications folder (Mac) or Start Menu/Desktop (Windows).
 
-### Setup
+**For Developers/Contributors:**
 
-1. Install dependencies:
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/cellwebb/mcp-palette.git
+   cd mcp-palette
+   ```
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Run the app in development mode:
+   ```bash
+   npm run electron:dev
+   ```
+4. Build a distributable version (installer/binary):
+   ```bash
+   npm run electron:build
+   ```
+   The output will appear in the `dist/` directory.
 
-```bash
-npm install
-```
-
-2. Start the application in development mode:
-
-```bash
-npm run electron:dev
-```
-
-Alternatively, use the provided start script:
-
-```bash
-chmod +x start.sh  # Make the script executable (first time only)
-./start.sh
-```
+**Note:**
+- If you need a Windows or Linux installer and are on a Mac, use GitHub Actions or a Windows/Linux machine to build for those platforms. See below for cross-platform automation.
 
 ## 🏗️ Development
 
@@ -66,6 +71,15 @@ npm run dev
 # Start Electron with Vite in development mode
 npm run electron:dev
 ```
+
+### Cross-Platform Builds & Automated Releases
+
+To build installers for all platforms and automate uploading to GitHub Releases:
+- Use GitHub Actions to build on Windows, Mac, and Linux runners.
+- Configure Electron Builder in your workflow to upload artifacts to Releases automatically.
+- See the [Electron Builder docs on CI/CD](https://www.electron.build/auto-update#github-actions) for sample workflows.
+
+If you need help setting up a workflow, let us know!
 
 ## 📦 Building for Production
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://github.com/cellwebb/mcp-palette/actions/workflows/ci.yml/badge.svg)](https://github.com/cellwebb/mcp-palette/actions/workflows/ci.yml)
 [![Coverage Status](https://codecov.io/gh/cellwebb/mcp-palette/branch/main/graph/badge.svg)](https://codecov.io/gh/cellwebb/mcp-palette)
 [![npm version](https://img.shields.io/npm/v/mcp-palette.svg)](https://www.npmjs.com/package/mcp-palette)
-[![License: MIT](https://img.shields.io/npm/l/mcp-palette.svg)](https://github.com/cellwebb/mcp-palette/blob/main/LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?logo=opensourceinitiative&logoColor=white)](https://opensource.org/licenses/MIT)
 
 MCP Palette is a modern, user-friendly desktop application for managing Model Context Protocol (MCP) server configurations. It provides a centralized interface to configure, manage, and deploy MCP servers for use with Large Language Models (LLMs) and AI assistants.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,61 @@
+# Architecture Overview
+
+MCP Palette is a cross-platform desktop application built with Electron, Vite, and React. It is designed to provide a modern, user-friendly interface for managing Model Context Protocol (MCP) server configurations.
+
+## High-Level Structure
+
+```
+mcp-palette/
+├── electron/                  # Electron main process and preload scripts
+│   ├── main.js                # Main process entry (window, IPC, menu)
+│   ├── preload.js             # Preload script for secure IPC
+│   └── store.js               # Data storage management (Electron Store)
+├── public/                    # Static assets (icons, etc.)
+├── src/                       # Frontend React code (render process)
+│   ├── App.jsx                # Main React component
+│   ├── components/            # UI components (ProfileSelector, ServerMasterList, etc.)
+│   ├── styles/                # CSS styles
+│   ├── utils/                 # Utility functions (profileUtils, helpers, validation)
+│   └── main.jsx               # Frontend entry point
+├── scripts/                   # Helper scripts for build/dev
+├── package.json               # Project manifest, scripts, dependencies
+└── vite.config.js             # Vite configuration
+```
+
+## Key Concepts
+
+### 1. Electron Main Process (`electron/main.js`)
+- Responsible for creating application windows, handling IPC, and managing the app lifecycle.
+- Loads the frontend (React app) via Vite dev server (development) or built files (production).
+- Sets up a secure context via `preload.js` for communication between renderer and main process.
+
+### 2. Renderer Process (React + Vite)
+- The UI is built with React and bundled by Vite for fast development and production builds.
+- Main entry: `src/main.jsx` → `src/App.jsx` → `src/components/`
+- Handles all user interactions, configuration editing, and state management.
+
+### 3. Data Storage
+- Uses `electron-store` for persistent storage of MCP profiles and server configurations on the user's machine.
+- Data is accessed and mutated via IPC between renderer and main process.
+
+### 4. Profiles & Server Master List
+- **Server Master List:** Central repository of base server configurations.
+- **Profiles:** User-defined collections of servers, with optional overrides for customization.
+- **Overrides:** Profile-specific changes that take precedence over master server settings.
+
+### 5. Testing
+- Uses Jest and React Testing Library for robust unit and integration tests.
+- Mocks and utilities are provided for testing Electron and React components.
+
+## Build & Release
+- Vite is used for fast frontend builds and hot module replacement.
+- Electron Builder packages the app for Mac, Windows, and Linux.
+- GitHub Actions automate CI (tests) and multi-platform releases.
+
+## Extensibility
+- Modular React components and utilities for easy feature expansion.
+- IPC and Electron Store usage make it easy to add new data types or settings.
+
+---
+
+For more details, see the [Usage Guide](./USAGE.md) and [Release Guide](./RELEASING.md).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing Guide
+
+Thank you for your interest in contributing to MCP Palette!
+
+## How to Contribute
+
+1. **Fork the repository** on GitHub.
+2. **Clone your fork** locally:
+   ```bash
+   git clone https://github.com/your-username/mcp-palette.git
+   cd mcp-palette
+   ```
+3. **Create a new branch** for your feature or fix:
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+4. **Make your changes** and commit them with clear messages.
+5. **Push your branch** to your fork:
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+6. **Open a Pull Request** on GitHub. Describe your changes and reference any issues.
+
+## Code Style & Practices
+- Follow the existing code style and structure.
+- Write clear, descriptive commit messages.
+- Add or update tests as appropriate.
+- Run tests locally with `npm test` before submitting a PR.
+
+## Reporting Issues
+- Use the GitHub Issues page to report bugs or request features.
+- Provide as much detail as possible, including steps to reproduce and screenshots if helpful.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,32 @@
+# Installation Guide
+
+## For End Users
+
+1. Visit the [GitHub Releases page](https://github.com/cellwebb/mcp-palette/releases).
+2. Download the installer or binary for your operating system (e.g., `.dmg` for Mac, `.exe` for Windows).
+3. Run the installer and follow the prompts to install MCP Palette.
+4. Launch MCP Palette from your Applications folder (Mac) or Start Menu/Desktop (Windows).
+
+## For Developers/Contributors
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/cellwebb/mcp-palette.git
+   cd mcp-palette
+   ```
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Run the app in development mode:
+   ```bash
+   npm run electron:dev
+   ```
+4. Build a distributable version (installer/binary):
+   ```bash
+   npm run electron:build
+   ```
+   The output will appear in the `dist/` directory.
+
+**Note:**
+- For Windows/Linux builds on Mac, use GitHub Actions or a native machine.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,35 @@
+# Release Guide
+
+This guide explains how to create a new release of MCP Palette and automate multi-platform builds.
+
+## Automated Release (Recommended)
+
+1. **Update version:**
+   - Bump the version in `package.json` (follow semantic versioning).
+2. **Commit and push changes:**
+   ```bash
+   git add .
+   git commit -m "chore: bump version to vX.Y.Z"
+   git push
+   ```
+3. **Create a new tag:**
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+4. **GitHub Actions will build and release:**
+   - The `.github/workflows/release.yml` workflow will build installers for Mac, Windows, and Linux and attach them to a new GitHub Release.
+
+## Manual Release (Advanced)
+
+1. Run the build script locally for your OS:
+   ```bash
+   npm run electron:build
+   ```
+2. Test the generated installer in the `dist/` directory.
+3. Go to the [GitHub Releases page](https://github.com/cellwebb/mcp-palette/releases), draft a new release, and upload the installer(s).
+
+## Notes
+- For cross-platform builds, prefer using GitHub Actions as described above.
+- Ensure all tests pass before releasing (`npm test`).
+- Update documentation and changelogs as needed for each release.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,39 @@
+# Usage Guide
+
+## Launching MCP Palette
+
+- **After installation:**
+  - On macOS: Open the Applications folder and double-click "MCP Palette."
+  - On Windows: Use the Start Menu or Desktop shortcut to launch the app.
+  - On Linux: Run the binary from your file manager or terminal.
+
+## Core Features
+
+### Profile Management
+- Create, edit, rename, and organize server configurations in profiles.
+- Switch between different profiles for various projects or environments.
+
+### Server Master List
+- Maintain a reusable library of server configurations.
+- Reference servers from the master list in your profiles.
+
+### Profile-Specific Overrides
+- Customize servers for specific profiles without duplicating configuration.
+- Overrides take precedence over master settings.
+
+### Enable/Disable Servers
+- Temporarily disable servers while preserving customizations.
+
+### JSON Editing
+- Directly edit configuration files for advanced customization.
+
+### Import/Export
+- Share configurations between teams and environments using import/export features.
+
+### Keyboard Shortcuts
+- Enter: Save changes
+- Escape: Cancel editing
+
+## Troubleshooting
+- If the app fails to launch, ensure you have the correct version for your OS and that all dependencies are installed.
+- For issues, consult the [GitHub Issues page](https://github.com/cellwebb/mcp-palette/issues).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mcp-palette",
   "version": "1.3.4",
   "description": "A palette for Model Context Protocol servers",
-  "author": "",
+  "author": "cellwebb",
   "license": "MIT",
   "main": "electron/main.js",
   "scripts": {
@@ -50,6 +50,25 @@
     "vite": "^4.4.5",
     "wait-on": "^7.0.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cellwebb/mcp-palette.git"
+  },
+  "keywords": [
+    "electron",
+    "vite",
+    "mcp",
+    "palette",
+    "llm",
+    "ai",
+    "desktop"
+  ],
+  "files": [
+    "dist",
+    "electron",
+    "src",
+    "main.js"
+  ],
   "build": {
     "appId": "com.electron.mcp-palette",
     "productName": "MCP Palette",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:coverage": "jest --coverage",
     "test:validator": "jest src/utils/validation/__tests__/mcpValidator.test.js",
     "test:components": "jest src/components",
-    "test:validation": "jest src/components/validation"
+    "test:validation": "jest src/components/validation",
+    "electron:build": "electron-builder build --mac --x64 --dir"
   },
   "dependencies": {
     "electron-store": "^8.1.0",
@@ -78,6 +79,7 @@
     ],
     "mac": {
       "target": "dir"
-    }
+    },
+    "dir": "dist"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:validator": "jest src/utils/validation/__tests__/mcpValidator.test.js",
     "test:components": "jest src/components",
     "test:validation": "jest src/components/validation",
-    "electron:build": "electron-builder build --mac --x64 --dir"
+    "electron:build": "electron-builder"
   },
   "dependencies": {
     "electron-store": "^8.1.0",
@@ -79,7 +79,6 @@
     ],
     "mac": {
       "target": "dir"
-    },
-    "dir": "dist"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-palette",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "A palette for Model Context Protocol servers",
   "author": "cellwebb",
   "license": "MIT",


### PR DESCRIPTION
## PR Summary: Release v1.3.5 Preparation and Workflow Fixes

This PR includes the necessary changes to finalize the v1.3.5 release process and incorporates several improvements to documentation and code quality accumulated since the last release.

**Key Changes:**

*   **CI/CD Fix:**
    *   Added `permissions: contents: write` to the `.github/workflows/release.yml` workflow. This grants the `GITHUB_TOKEN` the necessary permissions to create GitHub releases, resolving the 403 error encountered previously.
*   **Documentation:**
    *   Created comprehensive documentation suite in the `docs/` directory:
        *   `INSTALLATION.md`: Guide for setting up the application.
        *   `USAGE.md`: Instructions on how to use MCP Palette.
        *   `CONTRIBUTING.md`: Guidelines for contributing to the project.
        *   `RELEASING.md`: Steps for maintainers to create new releases.
        *   `ARCHITECTURE.md`: Overview of the project's structure.
    *   Updated `README.md` to include links to all new documentation pages.
*   **Code Quality & Testing:**
    *   Added `.codecov.yml` to configure code coverage reporting via Codecov, setting thresholds and ignoring specific files/directories.
    *   (Included from prior work) Refactored UUID handling to use the standard `uuid` package, removing custom implementations.
    *   (Included from prior work) Fixed bugs in the `deepMerge` utility and added extensive test cases for edge conditions.
*   **Version Bump:**
    *   Updated [package.json](cci:7://file:///Users/cell/projects/mcp-palette/package.json:0:0-0:0) version to `1.3.5`.

**Context:**

This work addresses the blockers preventing successful automated releases and significantly improves the project's documentation and maintainability.

**Note:** This PR does not address the `npm audit` vulnerabilities reported for `vite`/`esbuild`. These will be tackled in a separate effort due to the potential for breaking changes associated with the recommended `vite` upgrade.